### PR TITLE
feat: add test suite and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: script/lint
+      - run: script/test

--- a/biome.json
+++ b/biome.json
@@ -26,6 +26,6 @@
 		}
 	},
 	"files": {
-		"includes": ["src/**/*.ts", "astro.config.mjs"]
+		"includes": ["src/**/*.ts", "astro.config.mjs", "vitest.config.ts"]
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.1",
         "tailwindcss": "^4.2.1",
+        "vitest": "^4.1.0",
         "wrangler": "^4.73.0"
       }
     },
@@ -2027,6 +2028,13 @@
       "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
       "license": "CC0-1.0"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
@@ -2312,6 +2320,17 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2320,6 +2339,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2386,6 +2412,119 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -2456,6 +2595,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astring": {
@@ -2596,6 +2745,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -2712,6 +2871,13 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -3220,6 +3386,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -5893,6 +6069,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -5938,6 +6121,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -6035,6 +6232,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyclip": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
@@ -6067,6 +6271,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -6556,6 +6770,88 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -6573,6 +6869,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workerd": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.1",
     "tailwindcss": "^4.2.1",
+    "vitest": "^4.1.0",
     "wrangler": "^4.73.0"
   }
 }

--- a/script/test
+++ b/script/test
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")/.."
+npx vitest run

--- a/src/lib/mdx-to-prose.test.ts
+++ b/src/lib/mdx-to-prose.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { mdxToProse } from "./mdx-to-prose";
+
+describe("mdxToProse", () => {
+	it("returns empty string for null/undefined/empty input", () => {
+		expect(mdxToProse(null)).toBe("");
+		expect(mdxToProse(undefined)).toBe("");
+		expect(mdxToProse("")).toBe("");
+	});
+
+	it("preserves plain markdown", () => {
+		const md = "# Hello\n\nThis is a paragraph.\n\n- item one\n- item two";
+		expect(mdxToProse(md)).toBe(md);
+	});
+
+	it("strips script tags with content", () => {
+		const input = '<script>{`console.log("hi")`}</script>\n\nHello';
+		expect(mdxToProse(input)).toBe("Hello");
+	});
+
+	it("strips self-closing script tags", () => {
+		const input = '<script src="https://cdn.example.com/lib.js"/>\n\nHello';
+		expect(mdxToProse(input)).toBe("Hello");
+	});
+
+	it("strips script tags with src attribute", () => {
+		const input =
+			'<script src="https://cdn.example.com/lib.js"></script>\n\nHello';
+		expect(mdxToProse(input)).toBe("Hello");
+	});
+
+	it("strips HTML block elements with class attributes", () => {
+		const input =
+			'<div class="interactive">\n<button class="btn">Click</button>\n</div>\n\nParagraph here.';
+		expect(mdxToProse(input)).toBe("Paragraph here.");
+	});
+
+	it("strips self-closing HTML tags with attributes", () => {
+		const input = '<div id="foo" class="bar" />\n\nKeep this.';
+		expect(mdxToProse(input)).toBe("Keep this.");
+	});
+
+	it("strips wrapper divs but keeps surrounding content", () => {
+		const input = '<div id="wrapper">\n\nSome content\n\n</div>';
+		expect(mdxToProse(input)).toBe("Some content");
+	});
+
+	it("strips p tags with attributes but keeps their content", () => {
+		const input = '<p class="intro">Important text</p>';
+		expect(mdxToProse(input)).toBe("Important text");
+	});
+
+	it("collapses excessive blank lines", () => {
+		const input = "Line one\n\n\n\n\nLine two";
+		expect(mdxToProse(input)).toBe("Line one\n\nLine two");
+	});
+
+	it("handles a realistic MDX snippet", () => {
+		const input = [
+			"# Lesson Title",
+			"",
+			"Some intro text.",
+			"",
+			'<script src="https://cdn.example.com/confetti.js"></script>',
+			"",
+			'<div class="interactive-widget">',
+			'  <button class="btn-primary">Do the thing</button>',
+			"</div>",
+			"",
+			"## Next Section",
+			"",
+			"More content here.",
+		].join("\n");
+
+		const result = mdxToProse(input);
+		expect(result).toContain("# Lesson Title");
+		expect(result).toContain("Some intro text.");
+		expect(result).toContain("## Next Section");
+		expect(result).toContain("More content here.");
+		expect(result).not.toContain("<script");
+		expect(result).not.toContain("<button");
+	});
+});

--- a/src/lib/progress.test.ts
+++ b/src/lib/progress.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createStudent, getProgress, markLessonComplete } from "./progress";
+
+/** Simple in-memory KV mock. */
+function createMockKv(): KVNamespace {
+	const store = new Map<string, string>();
+	return {
+		get: vi.fn(async (key: string, format?: string) => {
+			const val = store.get(key) ?? null;
+			if (val && format === "json") return JSON.parse(val);
+			return val;
+		}),
+		put: vi.fn(async (key: string, value: string) => {
+			store.set(key, value);
+		}),
+		delete: vi.fn(async (key: string) => {
+			store.delete(key);
+		}),
+		list: vi.fn(),
+		getWithMetadata: vi.fn(),
+	} as unknown as KVNamespace;
+}
+
+describe("createStudent", () => {
+	it("creates a new student with empty progress", async () => {
+		const kv = createMockKv();
+		const progress = await createStudent(kv, "curious-hacker-1234");
+
+		expect(progress.completedLessons).toEqual([]);
+		expect(progress.createdAt).toBeTruthy();
+		expect(progress.updatedAt).toBeTruthy();
+		expect(kv.put).toHaveBeenCalledWith(
+			"student:curious-hacker-1234",
+			expect.any(String),
+		);
+	});
+});
+
+describe("getProgress", () => {
+	let kv: KVNamespace;
+
+	beforeEach(() => {
+		kv = createMockKv();
+	});
+
+	it("returns null for a non-existent student", async () => {
+		const result = await getProgress(kv, "nobody-here-0000");
+		expect(result).toBeNull();
+	});
+
+	it("returns progress for an existing student", async () => {
+		await createStudent(kv, "sharp-coder-5678");
+		const result = await getProgress(kv, "sharp-coder-5678");
+
+		expect(result).not.toBeNull();
+		expect(result?.completedLessons).toEqual([]);
+	});
+
+	it("normalizes legacy string-based completedLessons", async () => {
+		const legacy = {
+			completedLessons: ["enrollment", "install-opencode"],
+			createdAt: "2025-01-01T00:00:00.000Z",
+			updatedAt: "2025-06-15T00:00:00.000Z",
+		};
+		await kv.put("student:legacy-user-1111", JSON.stringify(legacy));
+
+		const result = await getProgress(kv, "legacy-user-1111");
+		expect(result).not.toBeNull();
+		expect(result?.completedLessons).toHaveLength(2);
+		expect(result?.completedLessons[0]).toEqual({
+			slug: "enrollment",
+			completedAt: "2025-06-15T00:00:00.000Z",
+			source: "browser",
+		});
+		expect(result?.completedLessons[1]).toEqual({
+			slug: "install-opencode",
+			completedAt: "2025-06-15T00:00:00.000Z",
+			source: "browser",
+		});
+	});
+});
+
+describe("markLessonComplete", () => {
+	let kv: KVNamespace;
+
+	beforeEach(() => {
+		kv = createMockKv();
+	});
+
+	it("returns null for a non-existent student", async () => {
+		const result = await markLessonComplete(
+			kv,
+			"nobody-here-0000",
+			"enrollment",
+		);
+		expect(result).toBeNull();
+	});
+
+	it("marks a lesson complete", async () => {
+		await createStudent(kv, "clever-maker-3333");
+		const result = await markLessonComplete(
+			kv,
+			"clever-maker-3333",
+			"enrollment",
+		);
+
+		expect(result).not.toBeNull();
+		expect(result?.completedLessons).toHaveLength(1);
+		expect(result?.completedLessons[0].slug).toBe("enrollment");
+		expect(result?.completedLessons[0].source).toBe("browser");
+	});
+
+	it("accepts a source parameter", async () => {
+		await createStudent(kv, "nimble-wizard-4444");
+		const result = await markLessonComplete(
+			kv,
+			"nimble-wizard-4444",
+			"install-opencode",
+			"agent",
+		);
+
+		expect(result?.completedLessons[0].source).toBe("agent");
+	});
+
+	it("is idempotent — marking the same lesson twice does not duplicate", async () => {
+		await createStudent(kv, "smooth-builder-5555");
+		await markLessonComplete(kv, "smooth-builder-5555", "enrollment");
+		const result = await markLessonComplete(
+			kv,
+			"smooth-builder-5555",
+			"enrollment",
+		);
+
+		expect(result?.completedLessons).toHaveLength(1);
+	});
+
+	it("can mark multiple different lessons", async () => {
+		await createStudent(kv, "lucky-scholar-6666");
+		await markLessonComplete(kv, "lucky-scholar-6666", "enrollment");
+		const result = await markLessonComplete(
+			kv,
+			"lucky-scholar-6666",
+			"install-opencode",
+		);
+
+		expect(result?.completedLessons).toHaveLength(2);
+		expect(result?.completedLessons.map((l) => l.slug)).toEqual([
+			"enrollment",
+			"install-opencode",
+		]);
+	});
+});

--- a/src/lib/student-id.test.ts
+++ b/src/lib/student-id.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { generateStudentId, isValidStudentId } from "./student-id";
+
+describe("isValidStudentId", () => {
+	it("accepts valid IDs", () => {
+		expect(isValidStudentId("curious-hacker-2019")).toBe(true);
+		expect(isValidStudentId("based-wizard-1000")).toBe(true);
+		expect(isValidStudentId("sharp-coder-9999")).toBe(true);
+	});
+
+	it("rejects IDs with wrong format", () => {
+		expect(isValidStudentId("")).toBe(false);
+		expect(isValidStudentId("single-1234")).toBe(false);
+		expect(isValidStudentId("too-many-parts-1234")).toBe(false);
+		expect(isValidStudentId("curious-hacker-123")).toBe(false); // 3 digits
+		expect(isValidStudentId("curious-hacker-12345")).toBe(false); // 5 digits
+		expect(isValidStudentId("Curious-hacker-1234")).toBe(false); // uppercase
+		expect(isValidStudentId("curious-hacker-abcd")).toBe(false); // letters instead of digits
+	});
+});
+
+describe("generateStudentId", () => {
+	it("returns a valid student ID without KV", async () => {
+		const id = await generateStudentId();
+		expect(isValidStudentId(id)).toBe(true);
+	});
+
+	it("generates different IDs on successive calls", async () => {
+		const ids = new Set<string>();
+		for (let i = 0; i < 20; i++) {
+			ids.add(await generateStudentId());
+		}
+		// With 14 adjectives * 11 nouns * 9000 numbers, collisions in 20 tries are near-impossible
+		expect(ids.size).toBe(20);
+	});
+
+	it("retries when KV returns a collision", async () => {
+		let calls = 0;
+		const mockKv = {
+			get: vi.fn(async () => {
+				calls++;
+				// First two calls return a collision, third returns null (available)
+				return calls <= 2 ? '{"some":"data"}' : null;
+			}),
+		} as unknown as KVNamespace;
+
+		const id = await generateStudentId(mockKv);
+		expect(isValidStudentId(id)).toBe(true);
+		expect(mockKv.get).toHaveBeenCalledTimes(3);
+	});
+
+	it("throws after exhausting retries", async () => {
+		const mockKv = {
+			get: vi.fn(async () => '{"some":"data"}'), // always collides
+		} as unknown as KVNamespace;
+
+		await expect(generateStudentId(mockKv, 3)).rejects.toThrow(
+			"Failed to generate a unique student ID after retries",
+		);
+		expect(mockKv.get).toHaveBeenCalledTimes(3);
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});


### PR DESCRIPTION
This PR adds automated test coverage and a CI workflow. Closes #6.

- Add vitest with 26 tests covering the three `src/lib/` modules: `mdx-to-prose` (prose stripping), `student-id` (generation and validation), and `progress` (KV CRUD with in-memory mock)
- Add `script/test` to match the existing scripts-to-rule-them-all convention
- Add a `ci.yml` GitHub Actions workflow that runs `script/lint` and `script/test` on all pushes and pull requests, separate from the existing deploy workflow
- Add `vitest.config.ts` to Biome's include list so it gets linted