### PR TITLE
fix: update page title format across the site

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,11 +3,12 @@ import "../styles/main.css";
 import { getCollection } from "astro:content";
 
 interface Props {
-  title: string;
+  title?: string;
   description?: string;
 }
 
 const { title, description = "Learn to use OpenCode, the free and open-source AI coding agent." } = Astro.props;
+const pageTitle = title ? `${title} | OpenCode School` : "OpenCode School";
 
 const lessons = (await getCollection("lessons")).sort((a, b) => a.data.order - b.data.order);
 const currentPath = Astro.url.pathname;
@@ -19,7 +20,7 @@ const currentPath = Astro.url.pathname;
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
-    <title>{title} - OpenCode School</title>
+    <title>{pageTitle}</title>
     <script is:inline>
       window.__schoolThemePalettes = {
         blue: {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,7 +7,7 @@ import { getCollection } from "astro:content";
 const lessons = (await getCollection("lessons")).sort((a, b) => a.data.order - b.data.order);
 ---
 
-<Base title="Home">
+<Base>
 
   <!-- Student ID card: always at top, shown once enrolled -->
   <div id="student-id-card" class="hidden mb-8 relative" style="max-width:420px; z-index:100">


### PR DESCRIPTION
This PR updates the `<title>` tag format across all pages. Closes #8.

- Homepage renders as `OpenCode School` (was `Home - OpenCode School`)
- All other pages use `{title} | OpenCode School` with a pipe separator (was ` - `)
- `title` prop on the Base layout is now optional — omitting it gives the bare site name
- No changes to `<meta name="description">` or other SEO metadata