### PR TITLE
fix: broken card shadow and slow confetti in production

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ const lessons = (await getCollection("lessons")).sort((a, b) => a.data.order - b
 
   <!-- Student ID card: always at top, shown once enrolled -->
   <div id="student-id-card" class="hidden mb-8 relative" style="max-width:420px; z-index:100">
-    <div class="theme-card-band rounded-2xl overflow-hidden shadow-2xl" style="aspect-ratio:85.6/54">
+    <div class="theme-card-band rounded-2xl overflow-hidden" style="aspect-ratio:85.6/54">
       <div class="flex flex-col justify-between h-full px-7 py-5">
         <p class="text-xs font-mono uppercase tracking-[0.3em] opacity-80">OpenCode Student ID</p>
         <p id="student-id-display" class="text-2xl font-mono font-bold tracking-tight"></p>
@@ -159,7 +159,7 @@ const lessons = (await getCollection("lessons")).sort((a, b) => a.data.order - b
     <p>Work through the lessons in order. Each one builds on the previous. Some lessons involve pasting prompts into OpenCode and letting it do the work for you. Progress is tracked through the website and synced with your OpenCode app.</p>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
+  <script is:inline src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
 
   <script is:inline>
     (function() {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -164,6 +164,7 @@
 .theme-card-band {
   background: var(--theme-solid);
   color: var(--theme-card-text);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
 }
 
 .lesson-link:hover .lesson-title {


### PR DESCRIPTION
This PR fixes two production-only regressions on the homepage:

- The student ID card shadow rendered as a grey solid rectangle instead of a soft blur. Tailwind v4's `shadow-2xl` relies on `@property` declarations to initialize `--tw-*` CSS variables, which weren't taking effect in production. Replaced with a direct `box-shadow` value on `.theme-card-band`.
- The confetti effect took ~10 seconds to fire. Astro was bundling the canvas-confetti CDN `<script>` tag through Vite, converting it to an ES module `import` that deferred execution. Added `is:inline` to preserve it as a classic script tag.

Both issues worked fine in dev because Astro's dev server handles script processing differently than the production build.