### PR TITLE
fix: remove text editor as a prerequisite

### DIFF
--- a/src/content/lessons/01-prerequisites.mdx
+++ b/src/content/lessons/01-prerequisites.mdx
@@ -4,7 +4,7 @@ slug: prerequisites
 description: "What you need before getting started with OpenCode."
 order: 1
 quiz: false
-agentInstructions: "This lesson is informational. Confirm the student has a computer running macOS, Windows, or Linux, a text editor, and an internet connection."
+agentInstructions: "This lesson is informational. Confirm the student has a computer running macOS, Windows, or Linux and an internet connection."
 ---
 
 Before we install anything, let's make sure you have what you need. Your browser can detect most of this automatically:
@@ -61,13 +61,9 @@ OpenCode runs on **macOS**, **Windows**, and **Linux**. Any computer from the la
 
 You can also configure OpenCode to use models running locally on your own machine using tools like [Ollama](https://ollama.com) and [LM Studio](https://lmstudio.ai), but that's optional and not required for completing the OpenCode School curriculum.
 
-## A text editor
-
-You'll need a [text editor](/glossary#text-editor) for viewing and editing OpenCode's configuration files. OpenCode itself handles most file creation and editing — the text editor is mainly for when you want to manually inspect or tweak things.
-
 ## That's it!
 
-No special software to install yet, no accounts to create. If you have a computer with an internet connection and a text editor, you're ready for the next lesson.
+No special software to install yet, no accounts to create. If you have a computer with an internet connection, you're ready for the next lesson.
 
 <script>{`
 document.addEventListener("DOMContentLoaded", function() {

--- a/src/content/lessons/03-configuration.mdx
+++ b/src/content/lessons/03-configuration.mdx
@@ -75,7 +75,7 @@ Config changes take effect the next time OpenCode starts. Once the file is creat
 
 ## Verify your config
 
-After OpenCode creates the file, you can open it in your text editor to confirm it looks right:
+After OpenCode creates the file, ask it to show you the contents to confirm it looks right:
 
 <div id="verify-config-section" class="not-prose">
 

--- a/src/content/lessons/04-permissions.mdx
+++ b/src/content/lessons/04-permissions.mdx
@@ -31,7 +31,7 @@ When OpenCode asks for permission, you'll see three options:
 
 ## Tighten your permissions
 
-Let's edit your global config to add some safety guardrails. Open `~/.config/opencode/opencode.jsonc` in your text editor and replace its contents with:
+Let's edit your global config to add some safety guardrails. Ask OpenCode to replace the contents of `~/.config/opencode/opencode.jsonc` with:
 
 ```jsonc
 {

--- a/src/content/lessons/05-instructions.mdx
+++ b/src/content/lessons/05-instructions.mdx
@@ -60,9 +60,9 @@ The more specific your instructions, the better OpenCode will work for you.
 
 ## Edit it anytime
 
-Your AGENTS.md is a plain text file. Open it in your text editor whenever you want to add, change, or remove rules. Changes take effect on the next session.
+Your AGENTS.md is a plain text file. Ask OpenCode to update it whenever you want to add, change, or remove rules. Changes take effect on the next session.
 
-You can also ask OpenCode to update it for you:
+For example:
 
 ```
 Add a rule to my global AGENTS.md: always use semantic commit messages when making git commits.


### PR DESCRIPTION
This PR removes the text editor requirement from the prerequisites lesson and updates references throughout the course to keep the focus on using OpenCode itself.

- `01-prerequisites.mdx` — removes the `## A text editor` section entirely and updates `agentInstructions` and the closing paragraph
- `03-configuration.mdx` — rewords "open in your text editor" to "ask OpenCode to show you"
- `04-permissions.mdx` — rewords manual file editing instruction to ask OpenCode to update the file
- `05-instructions.mdx` — rewords "open in your text editor" to "ask OpenCode to update it"

The glossary entry for "text editor" is left intact as a reference.