### PR TITLE
feat: add intake survey to tailor lessons to student experience

### DIFF
--- a/public/api/openapi.json
+++ b/public/api/openapi.json
@@ -89,6 +89,55 @@
         }
       }
     },
+    "/api/profile/{studentId}": {
+      "put": {
+        "summary": "Save student profile",
+        "description": "Saves or replaces the student's intake profile. All fields are optional — only provided fields are stored.",
+        "parameters": [
+          {
+            "name": "studentId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "example": "analytical-pilgrim-5076"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/StudentProfile" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Profile saved; returns updated progress",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Progress" }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "404": {
+            "description": "Student not found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/progress/{studentId}": {
       "get": {
         "summary": "Get student progress",
@@ -216,6 +265,38 @@
         },
         "required": ["slug", "completedAt", "source"]
       },
+      "StudentProfile": {
+        "type": "object",
+        "description": "Optional intake profile collected during enrollment. All fields are optional.",
+        "properties": {
+          "isSoftwareEngineer": {
+            "type": "boolean",
+            "description": "Whether the student is a software engineer.",
+            "example": true
+          },
+          "terminalComfort": {
+            "type": "string",
+            "enum": ["beginner", "some", "comfortable"],
+            "description": "Self-reported terminal comfort level.",
+            "example": "some"
+          },
+          "primaryGoal": {
+            "type": "string",
+            "enum": ["ai-coding", "automate", "build-projects", "curious"],
+            "description": "Primary reason for taking the course.",
+            "example": "build-projects"
+          },
+          "aiProviders": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["openai", "anthropic", "google", "local", "none"]
+            },
+            "description": "AI providers the student currently uses.",
+            "example": ["anthropic", "openai"]
+          }
+        }
+      },
       "Progress": {
         "type": "object",
         "properties": {
@@ -223,6 +304,10 @@
             "type": "array",
             "items": { "$ref": "#/components/schemas/CompletedLesson" },
             "example": [{ "slug": "installation", "completedAt": "2026-03-17T12:00:00Z", "source": "browser" }]
+          },
+          "profile": {
+            "$ref": "#/components/schemas/StudentProfile",
+            "description": "Intake profile, if the student completed the survey."
           },
           "createdAt": { "type": "string", "format": "date-time" },
           "updatedAt": { "type": "string", "format": "date-time" }

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -10,8 +10,20 @@ export interface CompletedLesson {
 	source: CompletionSource;
 }
 
+export interface StudentProfile {
+	/** Is the student a software engineer? */
+	isSoftwareEngineer?: boolean;
+	/** Self-reported terminal comfort: "beginner" | "some" | "comfortable" */
+	terminalComfort?: "beginner" | "some" | "comfortable";
+	/** Primary goal for taking the course */
+	primaryGoal?: "ai-coding" | "automate" | "build-projects" | "curious";
+	/** AI providers the student currently uses */
+	aiProviders?: ("openai" | "anthropic" | "google" | "local" | "none")[];
+}
+
 export interface StudentProgress {
 	completedLessons: CompletedLesson[];
+	profile?: StudentProfile;
 	createdAt: string;
 	updatedAt: string;
 }
@@ -19,6 +31,7 @@ export interface StudentProgress {
 // Legacy records stored completedLessons as string[]. Normalize on read.
 function normalizeProgress(raw: {
 	completedLessons: (string | CompletedLesson)[];
+	profile?: StudentProfile;
 	createdAt: string;
 	updatedAt: string;
 }): StudentProgress {
@@ -47,6 +60,7 @@ export async function getProgress(
 ): Promise<StudentProgress | null> {
 	const raw = await kv.get<{
 		completedLessons: (string | CompletedLesson)[];
+		profile?: StudentProfile;
 		createdAt: string;
 		updatedAt: string;
 	}>(kvKey(studentId), "json");
@@ -64,6 +78,24 @@ export async function createStudent(
 		createdAt: now,
 		updatedAt: now,
 	};
+	await kv.put(kvKey(studentId), JSON.stringify(progress));
+	return progress;
+}
+
+/**
+ * Save (or replace) the student's profile. Returns the updated progress,
+ * or null if the student doesn't exist.
+ */
+export async function updateProfile(
+	kv: KVNamespace,
+	studentId: string,
+	profile: StudentProfile,
+): Promise<StudentProgress | null> {
+	const progress = await getProgress(kv, studentId);
+	if (!progress) return null;
+
+	progress.profile = profile;
+	progress.updatedAt = new Date().toISOString();
 	await kv.put(kvKey(studentId), JSON.stringify(progress));
 	return progress;
 }

--- a/src/pages/api/profile/[studentId].ts
+++ b/src/pages/api/profile/[studentId].ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { env } from "cloudflare:workers";
+import type { APIRoute } from "astro";
+import { type StudentProfile, updateProfile } from "../../../lib/progress";
+import { isValidStudentId } from "../../../lib/student-id";
+
+const corsHeaders = {
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Methods": "PUT, OPTIONS",
+	"Access-Control-Allow-Headers": "Content-Type",
+};
+
+function notFound(message: string) {
+	return new Response(JSON.stringify({ error: message }), {
+		status: 404,
+		headers: { "Content-Type": "application/json", ...corsHeaders },
+	});
+}
+
+function badRequest(message: string) {
+	return new Response(JSON.stringify({ error: message }), {
+		status: 400,
+		headers: { "Content-Type": "application/json", ...corsHeaders },
+	});
+}
+
+const TERMINAL_COMFORT_VALUES = ["beginner", "some", "comfortable"] as const;
+const PRIMARY_GOAL_VALUES = [
+	"ai-coding",
+	"automate",
+	"build-projects",
+	"curious",
+] as const;
+const AI_PROVIDER_VALUES = [
+	"openai",
+	"anthropic",
+	"google",
+	"local",
+	"none",
+] as const;
+
+export const OPTIONS: APIRoute = async () => {
+	return new Response(null, { status: 204, headers: corsHeaders });
+};
+
+export const PUT: APIRoute = async ({ params, request }) => {
+	const { studentId } = params;
+	if (!studentId || !isValidStudentId(studentId)) {
+		return badRequest("Invalid student ID format");
+	}
+
+	let body: Partial<StudentProfile>;
+	try {
+		body = await request.json();
+	} catch {
+		return badRequest("Invalid JSON body");
+	}
+
+	const profile: StudentProfile = {};
+
+	if (typeof body.isSoftwareEngineer === "boolean") {
+		profile.isSoftwareEngineer = body.isSoftwareEngineer;
+	}
+
+	if (
+		body.terminalComfort !== undefined &&
+		TERMINAL_COMFORT_VALUES.includes(
+			body.terminalComfort as (typeof TERMINAL_COMFORT_VALUES)[number],
+		)
+	) {
+		profile.terminalComfort = body.terminalComfort;
+	}
+
+	if (
+		body.primaryGoal !== undefined &&
+		PRIMARY_GOAL_VALUES.includes(
+			body.primaryGoal as (typeof PRIMARY_GOAL_VALUES)[number],
+		)
+	) {
+		profile.primaryGoal = body.primaryGoal;
+	}
+
+	if (Array.isArray(body.aiProviders)) {
+		profile.aiProviders = body.aiProviders.filter((p) =>
+			AI_PROVIDER_VALUES.includes(p as (typeof AI_PROVIDER_VALUES)[number]),
+		) as StudentProfile["aiProviders"];
+	}
+
+	const progress = await updateProfile(env.PROGRESS, studentId, profile);
+	if (!progress) {
+		return notFound("Student not found");
+	}
+
+	return new Response(JSON.stringify(progress), {
+		headers: { "Content-Type": "application/json", ...corsHeaders },
+	});
+};

--- a/src/pages/disenroll.astro
+++ b/src/pages/disenroll.astro
@@ -34,9 +34,9 @@ import Base from "../layouts/Base.astro";
 
   <script is:inline>
     document.getElementById("disenroll-button").addEventListener("click", function () {
-      localStorage.removeItem("studentId");
-      localStorage.removeItem("themeColor");
-      localStorage.removeItem("progress");
+      // Clear everything — this site owns the entire localStorage origin, so
+      // clear() is safer than a manual list that drifts as features are added.
+      localStorage.clear();
       document.getElementById("disenroll-confirm").classList.add("hidden");
       document.getElementById("disenroll-done").classList.remove("hidden");
       setTimeout(function () {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,6 +25,58 @@ const lessons = (await getCollection("lessons")).sort((a, b) => a.data.order - b
     </div>
   </div>
 
+  <!-- Intake survey: shown after fresh enrollment, hidden once submitted -->
+  <div id="intake-survey" class="hidden mb-12">
+    <h2 class="text-2xl font-bold mb-2">You're enrolled!</h2>
+    <p class="text-gray-600 dark:text-stone-400 mb-8">Before you dive in, answer a few quick questions so your lessons can be tailored to your experience level.</p>
+
+    <!-- Q1: Software engineer? -->
+    <div class="survey-question mb-6" data-question="isSoftwareEngineer">
+      <p class="font-medium mb-3">Are you a software engineer?</p>
+      <div class="flex gap-3 flex-wrap">
+        <button type="button" class="survey-option rounded-lg border border-gray-300 dark:border-stone-700 px-4 py-2 text-sm font-mono hover:border-current" data-value="true">Yes</button>
+        <button type="button" class="survey-option rounded-lg border border-gray-300 dark:border-stone-700 px-4 py-2 text-sm font-mono hover:border-current" data-value="false">No</button>
+      </div>
+    </div>
+
+    <!-- Q2: Terminal comfort -->
+    <div class="survey-question mb-6" data-question="terminalComfort">
+      <p class="font-medium mb-3">How comfortable are you with the terminal?</p>
+      <div class="flex gap-3 flex-wrap">
+        <button type="button" class="survey-option rounded-lg border border-gray-300 dark:border-stone-700 px-4 py-2 text-sm font-mono hover:border-current" data-value="beginner">Beginner</button>
+        <button type="button" class="survey-option rounded-lg border border-gray-300 dark:border-stone-700 px-4 py-2 text-sm font-mono hover:border-current" data-value="some">Some experience</button>
+        <button type="button" class="survey-option rounded-lg border border-gray-300 dark:border-stone-700 px-4 py-2 text-sm font-mono hover:border-current" data-value="comfortable">Very comfortable</button>
+      </div>
+    </div>
+
+    <!-- Q3: Primary goal -->
+    <div class="survey-question mb-6" data-question="primaryGoal">
+      <p class="font-medium mb-3">What's your main goal with OpenCode?</p>
+      <div class="flex gap-3 flex-wrap">
+        <button type="button" class="survey-option rounded-lg border border-gray-300 dark:border-stone-700 px-4 py-2 text-sm font-mono hover:border-current" data-value="ai-coding">AI-assisted coding</button>
+        <button type="button" class="survey-option rounded-lg border border-gray-300 dark:border-stone-700 px-4 py-2 text-sm font-mono hover:border-current" data-value="automate">Automate tasks</button>
+        <button type="button" class="survey-option rounded-lg border border-gray-300 dark:border-stone-700 px-4 py-2 text-sm font-mono hover:border-current" data-value="build-projects">Build projects</button>
+        <button type="button" class="survey-option rounded-lg border border-gray-300 dark:border-stone-700 px-4 py-2 text-sm font-mono hover:border-current" data-value="curious">Just curious</button>
+      </div>
+    </div>
+
+    <!-- Q4: AI providers (multi-select) -->
+    <div class="survey-question mb-8" data-question="aiProviders" data-multi="true">
+      <p class="font-medium mb-3">Which AI providers do you use? <span class="font-normal text-gray-500 dark:text-stone-500 text-sm">(pick all that apply)</span></p>
+      <div class="flex gap-3 flex-wrap">
+        <button type="button" class="survey-option rounded-lg border border-gray-300 dark:border-stone-700 px-4 py-2 text-sm font-mono hover:border-current" data-value="openai">OpenAI</button>
+        <button type="button" class="survey-option rounded-lg border border-gray-300 dark:border-stone-700 px-4 py-2 text-sm font-mono hover:border-current" data-value="anthropic">Anthropic</button>
+        <button type="button" class="survey-option rounded-lg border border-gray-300 dark:border-stone-700 px-4 py-2 text-sm font-mono hover:border-current" data-value="google">Google</button>
+        <button type="button" class="survey-option rounded-lg border border-gray-300 dark:border-stone-700 px-4 py-2 text-sm font-mono hover:border-current" data-value="local">Local models</button>
+        <button type="button" class="survey-option rounded-lg border border-gray-300 dark:border-stone-700 px-4 py-2 text-sm font-mono hover:border-current" data-value="none">None yet</button>
+      </div>
+    </div>
+
+    <a id="survey-submit" href="/lessons/installation" class="theme-button block w-full rounded-lg px-10 py-4 text-center font-mono font-semibold text-xl opacity-50 pointer-events-none" aria-disabled="true">
+      Proceed to Installation
+    </a>
+  </div>
+
   <!-- Page header: hidden once enrolled -->
   <div id="page-header" class="mb-8">
     <p class="text-xl text-gray-700 dark:text-gray-300 leading-relaxed">
@@ -309,10 +361,19 @@ const lessons = (await getCollection("lessons")).sort((a, b) => a.data.order - b
       function showEnrolled(studentId, animate, fast) {
         notEnrolledSection.classList.add("hidden");
         if (enrollBottomSection) enrollBottomSection.classList.add("hidden");
-        enrolledSection.classList.remove("hidden");
         pageHeader.classList.add("hidden");
         display.textContent = studentId;
         idCard.classList.remove("hidden");
+
+        var surveyDone = !!localStorage.getItem(SURVEY_DONE_KEY);
+
+        if (surveyDone) {
+          // Returning user who completed the survey — show lesson list
+          enrolledSection.classList.remove("hidden");
+        } else {
+          // New enrollment or returning before survey was answered — show survey
+          surveyEl.classList.remove("hidden");
+        }
 
         if (animate) {
           cipherReveal(studentId, fast, function() {
@@ -344,6 +405,99 @@ const lessons = (await getCollection("lessons")).sort((a, b) => a.data.order - b
           opt.disabled = disabled;
           opt.classList.toggle("opacity-60", disabled);
           opt.classList.toggle("cursor-not-allowed", disabled);
+        });
+      }
+
+      // ── Intake survey ────────────────────────────────────────────────────────
+      var surveyEl     = document.getElementById("intake-survey");
+      var surveySubmit = document.getElementById("survey-submit");
+      var SURVEY_DONE_KEY = "surveyDone";
+
+      // Theme-colored selected state for survey options
+      function getSurveySelectionStyle() {
+        return "border-[var(--theme-solid)] bg-[var(--theme-soft-bg)] dark:bg-[var(--theme-soft-bg-dark)] text-[var(--theme-solid)] dark:text-[var(--theme-soft-text-dark)]";
+      }
+
+      function updateSubmitState() {
+        if (!surveySubmit) return;
+        var questions = Array.prototype.slice.call(document.querySelectorAll(".survey-question"));
+        var allAnswered = questions.every(function(q) {
+          return q.querySelector(".survey-option.selected");
+        });
+        if (allAnswered) {
+          surveySubmit.classList.remove("opacity-50", "pointer-events-none");
+          surveySubmit.removeAttribute("aria-disabled");
+        } else {
+          surveySubmit.classList.add("opacity-50", "pointer-events-none");
+          surveySubmit.setAttribute("aria-disabled", "true");
+        }
+      }
+
+      // Wire up survey option clicks
+      document.querySelectorAll(".survey-question").forEach(function(question) {
+        var isMulti = question.getAttribute("data-multi") === "true";
+        question.querySelectorAll(".survey-option").forEach(function(btn) {
+          btn.addEventListener("click", function() {
+            if (!isMulti) {
+              question.querySelectorAll(".survey-option").forEach(function(b) {
+                b.classList.remove("selected");
+                b.removeAttribute("aria-pressed");
+                getSurveySelectionStyle().split(" ").forEach(function(cls) { b.classList.remove(cls); });
+              });
+            }
+            var isSelected = btn.classList.contains("selected");
+            if (isMulti && isSelected) {
+              btn.classList.remove("selected");
+              btn.removeAttribute("aria-pressed");
+              getSurveySelectionStyle().split(" ").forEach(function(cls) { btn.classList.remove(cls); });
+            } else {
+              btn.classList.add("selected");
+              btn.setAttribute("aria-pressed", "true");
+              getSurveySelectionStyle().split(" ").forEach(function(cls) { btn.classList.add(cls); });
+            }
+            updateSubmitState();
+          });
+        });
+      });
+
+      function collectProfile() {
+        var profile = {};
+        document.querySelectorAll(".survey-question").forEach(function(question) {
+          var key = question.getAttribute("data-question");
+          var isMulti = question.getAttribute("data-multi") === "true";
+          var selected = Array.prototype.slice.call(question.querySelectorAll(".survey-option.selected"));
+          if (selected.length === 0) return;
+          if (isMulti) {
+            profile[key] = selected.map(function(b) { return b.getAttribute("data-value"); });
+          } else {
+            var val = selected[0].getAttribute("data-value");
+            profile[key] = (val === "true") ? true : (val === "false") ? false : val;
+          }
+        });
+        return profile;
+      }
+
+      // Fire-and-forget profile save — don't block navigation
+      function saveProfile() {
+        var studentId = window.school.getStudentId();
+        if (!studentId) return;
+        localStorage.setItem(SURVEY_DONE_KEY, "1");
+        fetch("/api/profile/" + studentId, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(collectProfile()),
+        }).catch(function() { /* non-critical */ });
+      }
+
+      // Intercept the <a> click: save profile then let the browser navigate
+      if (surveySubmit) {
+        surveySubmit.addEventListener("click", function(e) {
+          if (surveySubmit.getAttribute("aria-disabled") === "true") {
+            e.preventDefault();
+            return;
+          }
+          saveProfile();
+          // navigation proceeds naturally
         });
       }
 
@@ -400,6 +554,7 @@ const lessons = (await getCollection("lessons")).sort((a, b) => a.data.order - b
           }
         });
       });
+
     })();
   </script>
 </Base>

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -18,6 +18,17 @@ When the lesson criteria are met, mark the lesson complete via API before tellin
 
 When presenting multiple choice questions, do not label any answer choice as "Recommended".
 
+## Student profile
+
+Progress records may include a \`profile\` object with information the student provided during enrollment. Use this to tailor your teaching style:
+
+- \`isSoftwareEngineer\` (boolean) — if true, you can use technical terms (JSON, config files, CLI flags, etc.) without explaining them. If false, explain technical concepts in plain language.
+- \`terminalComfort\` ("beginner" | "some" | "comfortable") — adjust how much you explain terminal commands and shell syntax.
+- \`primaryGoal\` ("ai-coding" | "automate" | "build-projects" | "curious") — emphasize examples and use cases that match the student's goal.
+- \`aiProviders\` (array) — if the student already uses a provider (e.g. "anthropic"), you can reference it by name instead of speaking generically.
+
+If the profile is absent or a field is missing, use your best judgment based on the conversation.
+
 Download this schema to know how to interact with the API: https://opencode.school/api/openapi.json
 `;
 


### PR DESCRIPTION
This PR closes #33.

This adds a short intake survey shown to new students immediately after enrollment, directly below their student ID card. Answers are stored in KV alongside progress and surfaced to agents via the progress API so lesson content can be tailored to the student's background.

## What's included

- `StudentProfile` type added to `src/lib/progress.ts` with four fields: `isSoftwareEngineer`, `terminalComfort`, `primaryGoal`, `aiProviders`
- `PUT /api/profile/:studentId` endpoint saves the profile to KV
- `GET /api/progress/:studentId` already returns the profile (it's part of the progress blob)
- Survey UI on the homepage: shown after fresh enrollment, hidden on return visits once answered. Four questions with themed selected states. Submit button is disabled until all questions are answered, then navigates to `/lessons/installation` while saving the profile fire-and-forget.
- Lesson list hidden during first-time enrollment; only shown on return visits after the survey is done
- `llms.txt` updated with a "Student profile" section explaining how agents should use each field to adjust their teaching style
- OpenAPI spec updated with `StudentProfile` schema and new endpoint
- `disenroll.astro` switched from a manual `removeItem` list to `localStorage.clear()` so future additions can't silently break disenrollment