### PR TITLE
ci: add cron workflow to summon OpenCode on failing PR checks

### DIFF
--- a/.github/workflows/opencode-autofix.yml
+++ b/.github/workflows/opencode-autofix.yml
@@ -33,7 +33,6 @@ jobs:
             echo "--- Checking PR #$pr ---"
 
             # Check if any checks have failed
-            # gh pr checks returns non-zero if any check failed
             if gh pr checks "$pr" --json name,state --jq '.[] | select(.state == "FAILURE") | .name' | grep -q .; then
               echo "PR #$pr has failing checks."
             else
@@ -51,13 +50,13 @@ jobs:
             last_comment_author=$(gh pr view "$pr" --json comments --jq '.comments[-1].author.login // ""')
             last_comment_body=$(gh pr view "$pr" --json comments --jq '.comments[-1].body // ""')
 
-            if [ "$last_comment_author" = "github-actions" ] && echo "$last_comment_body" | grep -q "^/oc"; then
+            if [ "$last_comment_author" = "github-actions[bot]" ] && echo "$last_comment_body" | grep -q "^/oc"; then
               echo "PR #$pr: last comment is already a /oc from this workflow. Skipping."
               continue
             fi
 
             # Max retries: count total /oc comments from github-actions[bot] on this PR
-            retry_count=$(gh pr view "$pr" --json comments --jq '[.comments[] | select(.author.login == "github-actions" and (.body | startswith("/oc")))] | length')
+            retry_count=$(gh pr view "$pr" --json comments --jq '[.comments[] | select(.author.login == "github-actions[bot]" and (.body | startswith("/oc")))] | length')
 
             if [ "$retry_count" -ge "$MAX_RETRIES" ]; then
               echo "PR #$pr: reached max retries ($MAX_RETRIES). Leaving for a human."


### PR DESCRIPTION
This PR adds a scheduled GitHub Actions workflow that monitors open PRs created by OpenCode and automatically summons it when CI checks fail.

The workflow runs every 5 minutes and, for each open `app/opencode-agent` PR:

- Checks if any CI checks have failed (skips pending checks)
- Skips if the last comment is already a `/oc` invocation from this workflow (OpenCode hasn't responded yet)
- Skips if there have been 3+ autofix attempts total (leaves it for a human)
- Otherwise posts a `/oc` comment to trigger the existing opencode workflow

The natural comment cycle prevents spam: the cron posts `/oc`, OpenCode runs and comments back, CI runs again, and only if it fails again does the cron post another `/oc`.

Also supports `workflow_dispatch` for manual testing.