### PR TITLE
fix: scope preview cleanup to only deactivate the closed PR's deployments

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           gh api repos/${{ github.repository }}/deployments \
             -f environment=preview \
-            --jq '.[].id' | \
+            --jq '.[] | select(.ref == "${{ github.head_ref }}") | .id' | \
           while read id; do
             gh api repos/${{ github.repository }}/deployments/$id/statuses \
               --method POST \


### PR DESCRIPTION
This PR fixes a bug in the preview cleanup workflow where closing any PR would mark **all** preview deployments as inactive, not just the ones belonging to the closed PR.

The `cleanup-preview` job queries `environment=preview` and iterated over every deployment ID. Now it filters by `ref` to match only deployments from the closed PR's branch.

Also re-activated the deployment status for PR #57 which was a casualty of this bug.