### PR TITLE
fix: use per-PR environment names for preview deployments

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           deployment_id=$(echo '{
             "ref": "${{ github.head_ref }}",
-            "environment": "preview",
+            "environment": "preview/pr-${{ github.event.pull_request.number }}",
             "description": "PR #${{ github.event.pull_request.number }} preview",
             "auto_merge": false,
             "required_contexts": []
@@ -83,9 +83,8 @@ jobs:
 
       - name: Mark deployments inactive
         run: |
-          gh api repos/${{ github.repository }}/deployments \
-            -f environment=preview \
-            --jq '.[] | select(.ref == "${{ github.head_ref }}") | .id' | \
+          gh api "repos/${{ github.repository }}/deployments?environment=preview/pr-${{ github.event.pull_request.number }}" \
+            --jq '.[].id' | \
           while read id; do
             gh api repos/${{ github.repository }}/deployments/$id/statuses \
               --method POST \


### PR DESCRIPTION
This PR fixes the real root cause of preview deployments showing as "Inactive" on open PRs.

The previous fix (#62) scoped the cleanup job, but the actual problem was that all PRs shared a single `preview` GitHub environment. GitHub only allows one active deployment per environment, so each new PR deploy auto-deactivated all others.

Now each PR gets its own environment (`preview/pr-<number>`), so deployments are fully isolated. The cleanup job queries the per-PR environment directly instead of filtering by ref.

Also cleaned up all stale deployments from the old shared `preview` and `preview/pr-29` environments via the API.