### PR TITLE
feat: add desktop UI tour video to installation lesson

### DIFF
--- a/src/content/lessons/01-installation.mdx
+++ b/src/content/lessons/01-installation.mdx
@@ -146,8 +146,8 @@ Double-click OpenCode Desktop from your applications menu or dock, or use Spotli
 
 Watch this short video for a quick overview of OpenCode Desktop's user interface, which covers projects, sessions, prompts, agents, and models.
 
-<div class="my-8 border-2 leading-none lg:w-[calc(100%+8rem)] lg:max-w-[calc(100vw-4rem)]" style="border-color: var(--theme-solid);">
-  <video controls playsinline class="w-full block" src="https://assets.opencode.school/video/opencode-desktop-ui-tour-grey-bg.mp4" />
+<div class="my-8 border-2 overflow-hidden not-prose lg:w-[calc(100%+8rem)] lg:max-w-[calc(100vw-4rem)]" style={`border-color: var(--theme-solid); aspect-ratio: 1112/720;`}>
+  <video controls playsinline class="w-full h-full block object-cover" src="https://assets.opencode.school/video/opencode-desktop-ui-tour-grey-bg.mp4" />
 </div>
 
 ## Open a project


### PR DESCRIPTION
This PR adds the `opencode-desktop-ui-tour` video to the "Launch the app" section of the installation lesson. The video gives students a quick overview of Desktop's UI — projects, sessions, prompts, agents, and models.

The video files (WebM for Chrome/Firefox/Edge, MOV with HEVC alpha for Safari) were encoded from a green-screen source using `script/encode-video` and uploaded to R2 via `script/publish-video`. They're served from `https://assets.opencode.school/video/`.