### PR TITLE
feat: add admin dashboard for enrollment activity

### DIFF
--- a/src/lib/admin-stats.ts
+++ b/src/lib/admin-stats.ts
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import type { StudentProgress } from "./progress";
+
+export interface AdminStats {
+	generatedAt: string;
+	enrollment: {
+		total: number;
+		byDate: Record<string, number>;
+		thisWeek: number;
+		thisMonth: number;
+	};
+	lessons: {
+		completionCounts: Record<string, number>;
+		bySource: { browser: number; agent: number };
+	};
+	funnel: {
+		enrolled: number;
+		completedFirst: number;
+		completedHalf: number;
+		completedAll: number;
+	};
+	profiles: {
+		codingExperience: Record<string, number>;
+		editor: Record<string, number>;
+		os: Record<string, number>;
+		terminalComfort: Record<string, number>;
+		learningStyle: Record<string, number>;
+		depthPreference: Record<string, number>;
+	};
+	models: Record<string, number>;
+	recentEnrollments: Array<{
+		id: string;
+		createdAt: string;
+		lessonsCompleted: number;
+	}>;
+}
+
+/** Total number of non-stub lessons in the course. */
+const TOTAL_LESSONS = 13;
+
+/** Fetch all student records from KV and compute aggregate stats. */
+export async function getAdminStats(kv: KVNamespace): Promise<AdminStats> {
+	const records = await fetchAllStudents(kv);
+	const now = new Date();
+
+	const weekAgo = new Date(now);
+	weekAgo.setDate(weekAgo.getDate() - 7);
+
+	const monthAgo = new Date(now);
+	monthAgo.setMonth(monthAgo.getMonth() - 1);
+
+	const byDate: Record<string, number> = {};
+	let thisWeek = 0;
+	let thisMonth = 0;
+
+	const completionCounts: Record<string, number> = {};
+	const bySource = { browser: 0, agent: 0 };
+
+	let completedFirst = 0;
+	let completedHalf = 0;
+	let completedAll = 0;
+
+	const codingExperience: Record<string, number> = {};
+	const editor: Record<string, number> = {};
+	const os: Record<string, number> = {};
+	const terminalComfort: Record<string, number> = {};
+	const learningStyle: Record<string, number> = {};
+	const depthPreference: Record<string, number> = {};
+
+	const models: Record<string, number> = {};
+
+	const recentEnrollments: AdminStats["recentEnrollments"] = [];
+
+	for (const { id, data } of records) {
+		// Enrollment timeline
+		const created = new Date(data.createdAt);
+		const dateKey = data.createdAt.slice(0, 10);
+		byDate[dateKey] = (byDate[dateKey] || 0) + 1;
+		if (created >= weekAgo) thisWeek++;
+		if (created >= monthAgo) thisMonth++;
+
+		// Lesson completions
+		const lessons = data.completedLessons || [];
+		for (const l of lessons) {
+			completionCounts[l.slug] = (completionCounts[l.slug] || 0) + 1;
+			const source = l.source || "browser";
+			if (source === "agent") {
+				bySource.agent++;
+			} else {
+				bySource.browser++;
+			}
+			if (l.model) {
+				models[l.model] = (models[l.model] || 0) + 1;
+			}
+		}
+
+		// Funnel
+		if (lessons.length >= 1) completedFirst++;
+		if (lessons.length >= Math.ceil(TOTAL_LESSONS / 2)) completedHalf++;
+		if (lessons.length >= TOTAL_LESSONS) completedAll++;
+
+		// Profile
+		const profile = data.profile;
+		if (profile) {
+			if (profile.codingExperience) {
+				codingExperience[profile.codingExperience] =
+					(codingExperience[profile.codingExperience] || 0) + 1;
+			}
+			if (profile.editor) {
+				editor[profile.editor] = (editor[profile.editor] || 0) + 1;
+			}
+			if (profile.os) {
+				os[profile.os] = (os[profile.os] || 0) + 1;
+			}
+			if (profile.terminalComfort) {
+				terminalComfort[profile.terminalComfort] =
+					(terminalComfort[profile.terminalComfort] || 0) + 1;
+			}
+			if (profile.learningStyle) {
+				learningStyle[profile.learningStyle] =
+					(learningStyle[profile.learningStyle] || 0) + 1;
+			}
+			if (profile.depthPreference) {
+				depthPreference[profile.depthPreference] =
+					(depthPreference[profile.depthPreference] || 0) + 1;
+			}
+		}
+
+		// Recent enrollments (collect all, sort and slice later)
+		recentEnrollments.push({
+			id,
+			createdAt: data.createdAt,
+			lessonsCompleted: lessons.length,
+		});
+	}
+
+	// Sort recent enrollments by date descending, keep latest 20
+	recentEnrollments.sort(
+		(a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+	);
+
+	return {
+		generatedAt: now.toISOString(),
+		enrollment: {
+			total: records.length,
+			byDate,
+			thisWeek,
+			thisMonth,
+		},
+		lessons: { completionCounts, bySource },
+		funnel: {
+			enrolled: records.length,
+			completedFirst,
+			completedHalf,
+			completedAll,
+		},
+		profiles: {
+			codingExperience,
+			editor,
+			os,
+			terminalComfort,
+			learningStyle,
+			depthPreference,
+		},
+		models,
+		recentEnrollments: recentEnrollments.slice(0, 20),
+	};
+}
+
+// -- internal helpers --------------------------------------------------------
+
+interface StudentRecord {
+	id: string;
+	data: StudentProgress;
+}
+
+async function fetchAllStudents(kv: KVNamespace): Promise<StudentRecord[]> {
+	const keys: string[] = [];
+	let cursor: string | undefined;
+
+	// Paginate through all student keys
+	do {
+		const list = await kv.list({
+			prefix: "student:",
+			...(cursor ? { cursor } : {}),
+		});
+		for (const key of list.keys) {
+			keys.push(key.name);
+		}
+		cursor = list.list_complete ? undefined : list.cursor;
+	} while (cursor);
+
+	// Fetch all records in parallel
+	const results = await Promise.all(
+		keys.map(async (key) => {
+			const data = await kv.get<StudentProgress>(key, "json");
+			if (!data) return null;
+			return { id: key.replace("student:", ""), data };
+		}),
+	);
+
+	return results.filter((r): r is StudentRecord => r !== null);
+}

--- a/src/pages/admin.astro
+++ b/src/pages/admin.astro
@@ -1,0 +1,299 @@
+---
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Authentication is handled by Cloudflare Access (email domain: cloudflare.com).
+// No application-level auth check needed.
+
+import "../styles/main.css";
+import { env } from "cloudflare:workers";
+import { getAdminStats } from "../lib/admin-stats";
+
+const stats = await getAdminStats(env.PROGRESS);
+
+// Ordered lesson slugs for funnel/completion display
+const lessonOrder = [
+  "installation", "interview", "configuration", "permissions", "instructions",
+  "models", "commands", "skills", "tools", "agents", "sessions", "images", "workspaces",
+];
+
+// Sort enrollment dates chronologically
+const sortedDates = Object.entries(stats.enrollment.byDate).sort(([a], [b]) => a.localeCompare(b));
+
+// Sort lesson completions by count descending
+const sortedLessons = lessonOrder.map((slug) => ({
+  slug,
+  count: stats.lessons.completionCounts[slug] || 0,
+}));
+
+// Sort models by usage descending
+const sortedModels = Object.entries(stats.models).sort(([, a], [, b]) => b - a);
+
+function pct(n: number, total: number): string {
+  if (total === 0) return "0%";
+  return `${Math.round((n / total) * 100)}%`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short", day: "numeric", year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short", day: "numeric", hour: "numeric", minute: "2-digit",
+    timeZone: "UTC",
+  });
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Admin | OpenCode School</title>
+    <script is:inline>
+      if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+        document.documentElement.classList.add("dark");
+      }
+      window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+        document.documentElement.classList.toggle("dark", e.matches);
+      });
+    </script>
+  </head>
+  <body class="min-h-screen bg-white dark:bg-stone-950 text-gray-900 dark:text-stone-100">
+      <div class="max-w-5xl mx-auto px-6 py-10">
+        <div class="flex items-baseline justify-between mb-10">
+          <h1 class="text-2xl font-mono font-semibold">OpenCode School Admin</h1>
+          <span class="text-xs text-gray-400 dark:text-stone-500 font-mono">
+            Generated {formatDateTime(stats.generatedAt)} UTC
+          </span>
+        </div>
+
+        <!-- Summary cards -->
+        <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-10">
+          <div class="rounded-lg border border-gray-200 dark:border-stone-800 p-4">
+            <div class="text-3xl font-mono font-semibold">{stats.enrollment.total}</div>
+            <div class="text-sm text-gray-500 dark:text-stone-400 mt-1">Total students</div>
+          </div>
+          <div class="rounded-lg border border-gray-200 dark:border-stone-800 p-4">
+            <div class="text-3xl font-mono font-semibold">{stats.enrollment.thisWeek}</div>
+            <div class="text-sm text-gray-500 dark:text-stone-400 mt-1">This week</div>
+          </div>
+          <div class="rounded-lg border border-gray-200 dark:border-stone-800 p-4">
+            <div class="text-3xl font-mono font-semibold">{stats.enrollment.thisMonth}</div>
+            <div class="text-sm text-gray-500 dark:text-stone-400 mt-1">This month</div>
+          </div>
+          <div class="rounded-lg border border-gray-200 dark:border-stone-800 p-4">
+            <div class="text-3xl font-mono font-semibold">
+              {stats.lessons.bySource.browser + stats.lessons.bySource.agent}
+            </div>
+            <div class="text-sm text-gray-500 dark:text-stone-400 mt-1">Lessons completed</div>
+          </div>
+        </div>
+
+        <!-- Funnel -->
+        <section class="mb-10">
+          <h2 class="text-lg font-mono font-semibold mb-4">Funnel</h2>
+          <div class="space-y-2">
+            {[
+              { label: "Enrolled",            value: stats.funnel.enrolled },
+              { label: "Completed 1+ lesson",  value: stats.funnel.completedFirst },
+              { label: "Completed 7+ lessons", value: stats.funnel.completedHalf },
+              { label: "Completed all 13",     value: stats.funnel.completedAll },
+            ].map((step) => (
+              <div class="flex items-center gap-3">
+                <div class="w-36 text-sm text-gray-600 dark:text-stone-400 shrink-0">{step.label}</div>
+                <div class="flex-1 h-6 bg-gray-100 dark:bg-stone-900 rounded overflow-hidden">
+                  <div
+                    class="h-full bg-emerald-500 dark:bg-emerald-600 rounded"
+                    style={`width: ${stats.funnel.enrolled > 0 ? Math.max((step.value / stats.funnel.enrolled) * 100, step.value > 0 ? 2 : 0) : 0}%`}
+                  />
+                </div>
+                <div class="w-16 text-right text-sm font-mono">
+                  {step.value} <span class="text-gray-400 dark:text-stone-500">{pct(step.value, stats.funnel.enrolled)}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <!-- Lesson completion -->
+        <section class="mb-10">
+          <h2 class="text-lg font-mono font-semibold mb-4">Lesson completion</h2>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-left text-gray-500 dark:text-stone-400 border-b border-gray-200 dark:border-stone-800">
+                  <th class="py-2 pr-4 font-medium">Lesson</th>
+                  <th class="py-2 px-4 font-medium text-right">Completed</th>
+                  <th class="py-2 px-4 font-medium text-right">Rate</th>
+                  <th class="py-2 pl-4 font-medium">Distribution</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedLessons.map((lesson, i) => (
+                  <tr class="border-b border-gray-100 dark:border-stone-900">
+                    <td class="py-2 pr-4 font-mono">
+                      <span class="text-gray-400 dark:text-stone-600 mr-1">{String(i + 1).padStart(2, "0")}.</span>
+                      {lesson.slug}
+                    </td>
+                    <td class="py-2 px-4 text-right font-mono">{lesson.count}</td>
+                    <td class="py-2 px-4 text-right font-mono text-gray-500 dark:text-stone-400">
+                      {pct(lesson.count, stats.enrollment.total)}
+                    </td>
+                    <td class="py-2 pl-4 w-48">
+                      <div class="h-3 bg-gray-100 dark:bg-stone-900 rounded overflow-hidden">
+                        <div
+                          class="h-full bg-blue-500 dark:bg-blue-600 rounded"
+                          style={`width: ${stats.enrollment.total > 0 ? Math.max((lesson.count / stats.enrollment.total) * 100, lesson.count > 0 ? 2 : 0) : 0}%`}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div class="mt-3 text-xs text-gray-400 dark:text-stone-500">
+            Completion source: {stats.lessons.bySource.browser} browser, {stats.lessons.bySource.agent} agent
+          </div>
+        </section>
+
+        <!-- Enrollment timeline -->
+        <section class="mb-10">
+          <h2 class="text-lg font-mono font-semibold mb-4">Enrollment timeline</h2>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-left text-gray-500 dark:text-stone-400 border-b border-gray-200 dark:border-stone-800">
+                  <th class="py-2 pr-4 font-medium">Date</th>
+                  <th class="py-2 px-4 font-medium text-right">Enrollments</th>
+                  <th class="py-2 pl-4 font-medium">Volume</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedDates.map(([date, count]) => {
+                  const maxCount = Math.max(...sortedDates.map(([, c]) => c));
+                  return (
+                    <tr class="border-b border-gray-100 dark:border-stone-900">
+                      <td class="py-1.5 pr-4 font-mono">{formatDate(date)}</td>
+                      <td class="py-1.5 px-4 text-right font-mono">{count}</td>
+                      <td class="py-1.5 pl-4 w-48">
+                        <div class="h-3 bg-gray-100 dark:bg-stone-900 rounded overflow-hidden">
+                          <div
+                            class="h-full bg-violet-500 dark:bg-violet-600 rounded"
+                            style={`width: ${maxCount > 0 ? Math.max((count / maxCount) * 100, 2) : 0}%`}
+                          />
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- Model usage -->
+        {sortedModels.length > 0 && (
+          <section class="mb-10">
+            <h2 class="text-lg font-mono font-semibold mb-4">AI model usage</h2>
+            <div class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="text-left text-gray-500 dark:text-stone-400 border-b border-gray-200 dark:border-stone-800">
+                    <th class="py-2 pr-4 font-medium">Model</th>
+                    <th class="py-2 px-4 font-medium text-right">Completions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedModels.map(([model, count]) => (
+                    <tr class="border-b border-gray-100 dark:border-stone-900">
+                      <td class="py-1.5 pr-4 font-mono">{model}</td>
+                      <td class="py-1.5 px-4 text-right font-mono">{count}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        <!-- Profile breakdowns -->
+        <section class="mb-10">
+          <h2 class="text-lg font-mono font-semibold mb-4">Student profiles</h2>
+          <p class="text-sm text-gray-500 dark:text-stone-400 mb-4">
+            Based on {Object.values(stats.profiles.codingExperience).reduce((a, b) => a + b, 0)} students who completed the interview lesson.
+          </p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            {[
+              { title: "Coding experience",  data: stats.profiles.codingExperience },
+              { title: "Editor",             data: stats.profiles.editor },
+              { title: "Terminal comfort",   data: stats.profiles.terminalComfort },
+              { title: "Learning style",     data: stats.profiles.learningStyle },
+              { title: "Depth preference",   data: stats.profiles.depthPreference },
+              { title: "Operating system",   data: stats.profiles.os },
+            ].filter((section) => Object.keys(section.data).length > 0).map((section) => {
+              const total = Object.values(section.data).reduce((a, b) => a + b, 0);
+              const entries = Object.entries(section.data).sort(([, a], [, b]) => b - a);
+              return (
+                <div>
+                  <h3 class="text-sm font-medium text-gray-600 dark:text-stone-300 mb-2">{section.title}</h3>
+                  <div class="space-y-1">
+                    {entries.map(([key, count]) => (
+                      <div class="flex items-center gap-2 text-sm">
+                        <span class="w-28 truncate text-gray-500 dark:text-stone-400 font-mono">{key}</span>
+                        <div class="flex-1 h-2.5 bg-gray-100 dark:bg-stone-900 rounded overflow-hidden">
+                          <div
+                            class="h-full bg-amber-500 dark:bg-amber-600 rounded"
+                            style={`width: ${total > 0 ? Math.max((count / total) * 100, 4) : 0}%`}
+                          />
+                        </div>
+                        <span class="w-8 text-right font-mono text-gray-400 dark:text-stone-500">{count}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        <!-- Recent enrollments -->
+        <section class="mb-10">
+          <h2 class="text-lg font-mono font-semibold mb-4">Recent enrollments</h2>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-left text-gray-500 dark:text-stone-400 border-b border-gray-200 dark:border-stone-800">
+                  <th class="py-2 pr-4 font-medium">Student ID</th>
+                  <th class="py-2 px-4 font-medium">Enrolled</th>
+                  <th class="py-2 pl-4 font-medium text-right">Lessons done</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stats.recentEnrollments.map((student) => (
+                  <tr class="border-b border-gray-100 dark:border-stone-900">
+                    <td class="py-1.5 pr-4 font-mono">{student.id}</td>
+                    <td class="py-1.5 px-4 text-gray-500 dark:text-stone-400">{formatDateTime(student.createdAt)}</td>
+                    <td class="py-1.5 pl-4 text-right font-mono">{student.lessonsCompleted}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <footer class="text-xs text-gray-400 dark:text-stone-600 pt-4 border-t border-gray-200 dark:border-stone-800">
+          <a href="/" class="hover:underline">OpenCode School</a> admin dashboard.
+          Data is computed fresh on each page load from {stats.enrollment.total} KV records.
+        </footer>
+      </div>
+  </body>
+</html>

--- a/src/pages/api/admin/stats.ts
+++ b/src/pages/api/admin/stats.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Authentication is handled by Cloudflare Access (email domain: cloudflare.com).
+// No application-level auth check needed.
+
+import { env } from "cloudflare:workers";
+import type { APIRoute } from "astro";
+import { getAdminStats } from "../../../lib/admin-stats";
+
+export const GET: APIRoute = async () => {
+	const stats = await getAdminStats(env.PROGRESS);
+
+	return new Response(JSON.stringify(stats, null, 2), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+};

--- a/src/pages/api/openapi.json.ts
+++ b/src/pages/api/openapi.json.ts
@@ -380,6 +380,23 @@ export const GET: APIRoute = (context) => {
 					},
 				},
 			},
+			"/api/admin/stats": {
+				get: {
+					summary: "Get admin dashboard stats",
+					description:
+						"Returns aggregated enrollment, lesson completion, funnel, profile, and model usage statistics. Protected by Cloudflare Access (cloudflare.com email domain).",
+					responses: {
+						"200": {
+							description: "Admin stats",
+							content: {
+								"application/json": {
+									schema: { $ref: "#/components/schemas/AdminStats" },
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		components: {
 			schemas: {
@@ -531,6 +548,117 @@ export const GET: APIRoute = (context) => {
 						},
 					},
 					required: ["completedLessons", "createdAt", "updatedAt"],
+				},
+				AdminStats: {
+					type: "object",
+					description:
+						"Aggregated enrollment, completion, and profile statistics.",
+					properties: {
+						generatedAt: { type: "string", format: "date-time" },
+						enrollment: {
+							type: "object",
+							properties: {
+								total: { type: "integer" },
+								byDate: {
+									type: "object",
+									additionalProperties: { type: "integer" },
+								},
+								thisWeek: { type: "integer" },
+								thisMonth: { type: "integer" },
+							},
+							required: ["total", "byDate", "thisWeek", "thisMonth"],
+						},
+						lessons: {
+							type: "object",
+							properties: {
+								completionCounts: {
+									type: "object",
+									additionalProperties: { type: "integer" },
+								},
+								bySource: {
+									type: "object",
+									properties: {
+										browser: { type: "integer" },
+										agent: { type: "integer" },
+									},
+									required: ["browser", "agent"],
+								},
+							},
+							required: ["completionCounts", "bySource"],
+						},
+						funnel: {
+							type: "object",
+							properties: {
+								enrolled: { type: "integer" },
+								completedFirst: { type: "integer" },
+								completedHalf: { type: "integer" },
+								completedAll: { type: "integer" },
+							},
+							required: [
+								"enrolled",
+								"completedFirst",
+								"completedHalf",
+								"completedAll",
+							],
+						},
+						profiles: {
+							type: "object",
+							properties: {
+								codingExperience: {
+									type: "object",
+									additionalProperties: { type: "integer" },
+								},
+								editor: {
+									type: "object",
+									additionalProperties: { type: "integer" },
+								},
+								os: {
+									type: "object",
+									additionalProperties: { type: "integer" },
+								},
+								terminalComfort: {
+									type: "object",
+									additionalProperties: { type: "integer" },
+								},
+								learningStyle: {
+									type: "object",
+									additionalProperties: { type: "integer" },
+								},
+								depthPreference: {
+									type: "object",
+									additionalProperties: { type: "integer" },
+								},
+							},
+						},
+						models: {
+							type: "object",
+							additionalProperties: { type: "integer" },
+						},
+						recentEnrollments: {
+							type: "array",
+							items: {
+								type: "object",
+								properties: {
+									id: { type: "string" },
+									createdAt: {
+										type: "string",
+										format: "date-time",
+									},
+									lessonsCompleted: { type: "integer" },
+								},
+								required: ["id", "createdAt", "lessonsCompleted"],
+							},
+						},
+					},
+					required: [
+						"generatedAt",
+						"enrollment",
+						"lessons",
+						"funnel",
+						"profiles",
+						"models",
+						"recentEnrollments",
+					],
 				},
 				Error: {
 					type: "object",


### PR DESCRIPTION
This PR adds a server-rendered admin dashboard at `/admin` and a JSON API at `/api/admin/stats`. It scans all student records from the `PROGRESS` KV namespace and displays:

- Summary cards: total students, this week, this month, total lessons completed
- Funnel: enrolled → 1+ lesson → 7+ lessons → all 13
- Per-lesson completion table with counts, rates, and bar charts
- Enrollment timeline by date
- AI model usage breakdown
- Student profile distributions (coding experience, editor, OS, terminal comfort, learning style, depth preference)
- Recent enrollments (latest 20 students)

Authentication is handled by Cloudflare Access at the edge — only `@cloudflare.com` emails can access `/admin` and `/api/admin/*`. The Access application and policy are already configured on the account. No application-level auth code needed.

New files:
- `src/lib/admin-stats.ts` — stats aggregation engine (KV scan + compute)
- `src/pages/admin.astro` — standalone dashboard page (dark mode, Tailwind, no JS)
- `src/pages/api/admin/stats.ts` — JSON API endpoint
- Updated `src/pages/api/openapi.json.ts` with the new endpoint and `AdminStats` schema

Closes #73