### PR TITLE
Add tips and tricks page

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -532,6 +532,17 @@ const currentPath = Astro.url.pathname;
             About
           </a>
           <a
+            href="/tips"
+            class:list={[
+              "block px-3 py-1.5 rounded-md text-sm transition-colors",
+              currentPath === "/tips" || currentPath === "/tips/"
+                ? "theme-active-nav font-medium"
+                : "text-gray-600 hover:text-gray-900 hover:bg-gray-50 dark:text-stone-400 dark:hover:text-stone-200 dark:hover:bg-stone-800",
+            ]}
+          >
+            Tips
+          </a>
+          <a
             href="/glossary"
             class:list={[
               "block px-3 py-1.5 rounded-md text-sm transition-colors",

--- a/src/pages/tips.astro
+++ b/src/pages/tips.astro
@@ -1,0 +1,66 @@
+---
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export const prerender = true;
+
+import Base from "../layouts/Base.astro";
+---
+
+<Base title="Tips and Tricks" description="Practical tips for getting better results with OpenCode and OpenCode School.">
+  <div class="mb-6">
+    <a href="/" class="text-sm text-gray-500 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors">
+      &larr; All lessons
+    </a>
+  </div>
+
+  <header class="mb-8">
+    <h1 class="text-3xl font-bold">Tips and Tricks</h1>
+    <p class="text-gray-600 dark:text-stone-400 mt-2">Practical ways to get better results with OpenCode.</p>
+  </header>
+
+  <article class="prose dark:prose-invert max-w-none">
+    <h2>Remember that OpenCode and OpenCode School are flexible systems</h2>
+    <p>
+      You can choose your own adventure. Paint outside the lines. Be silly. Be
+      bossy.
+    </p>
+    <ul>
+      <li>
+        Want to cut to the chase? Say so: "Let's skip the long-winded
+        descriptions and just get these changes made."
+      </li>
+      <li>
+        Want to review your progress? Easy: "Let's revisit what we've covered
+        so far in school."
+      </li>
+      <li>
+        Want to do your lessons in another language? No problem: "Let's do
+        everything in Spanish!"
+      </li>
+    </ul>
+
+    <h2>Describe the goal</h2>
+    <p>
+      Talk about the <em>what</em>, not the <em>how</em>. The agent may come up
+      with approaches that are simpler or more effective than the first idea
+      you had in mind.
+    </p>
+    <p>
+      Keeping the conversation open to alternatives often leads to better
+      outcomes. Describe what you are trying to accomplish, not only the exact
+      tools or steps you expect.
+    </p>
+
+    <h2>Know when to give up and start over</h2>
+    <p>
+      Sometimes you end up in a rabbit hole: the agent makes a mistake, you try
+      to correct it, and things get worse. This happens to everyone.
+    </p>
+    <p>
+      The important skill is knowing when to reset. Do not be afraid to stop a
+      session, reflect on what you learned, and start a fresh one with clearer
+      instructions.
+    </p>
+  </article>
+</Base>


### PR DESCRIPTION
## Summary
- add a new `/tips` page with practical prompt advice based on issue #74
- keep the original guidance structure while polishing grammar and readability for web copy
- add a `Tips` link in the sidebar so the page is discoverable from all routes

## Verification
- ran `script/lint`

Closes #74