### PR TITLE
docs: add caveat that Plan mode is not a guaranteed sandbox

### DIFF
--- a/src/content/lessons/10-agents.mdx
+++ b/src/content/lessons/10-agents.mdx
@@ -4,7 +4,7 @@ slug: agents
 description: "Use Plan and Build agents to think before you act."
 order: 10
 quiz: true
-agentInstructions: "Cover these four topics: (1) what an agent means in OpenCode specifically — a specialized assistant configured for a particular task or workflow, distinct from the broader industry use of the word, (2) the Plan agent — conversational and read-only; it can read files and discuss the project but won't make any changes; use it to think out loud, explore options, and arrive at a clear plan, (3) the Build agent — the implementation agent with full access to read, write, and run things; use this once you know what you want to do, (4) the recommended workflow — start in Plan to think things through safely, switch to Build when ready to implement; Plan is optional but a good habit especially for complex or unfamiliar tasks. After teaching and quizzing, verify completion by asking the student to describe when they'd use Plan vs. Build and confirm they understand that Plan is read-only and Build can make changes."
+agentInstructions: "Cover these four topics: (1) what an agent means in OpenCode specifically — a specialized assistant configured for a particular task or workflow, distinct from the broader industry use of the word, (2) the Plan agent — conversational and read-only; it can read files and discuss the project but won't make any changes; use it to think out loud, explore options, and arrive at a clear plan — but note that Plan mode is not a hard sandbox and the agent may still occasionally run commands or make API calls that have side effects, (3) the Build agent — the implementation agent with full access to read, write, and run things; use this once you know what you want to do, (4) the recommended workflow — start in Plan to think things through safely, switch to Build when ready to implement; Plan is optional but a good habit especially for complex or unfamiliar tasks. After teaching and quizzing, verify completion by asking the student to describe when they'd use Plan vs. Build and confirm they understand that Plan is read-only by default but not a guaranteed sandbox, and that Build can make changes."
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'
@@ -19,6 +19,8 @@ OpenCode ships with two built-in agents: **Plan** and **Build**.
 
 Plan is a read-only conversational agent. It can read your files and discuss your project, but it won't make any changes. No files written, no commands run, nothing modified.
 
+That said, Plan mode is an instruction to the model, not a hard sandbox. Occasionally the agent may still make API calls or run commands that have side effects, so it's not a guaranteed protection against unintended changes.
+
 Use Plan when you want to:
 
 - Think through an approach before committing to it
@@ -26,7 +28,7 @@ Use Plan when you want to:
 - Ask questions and do research
 - Arrive at a clear plan before touching anything
 
-This makes Plan safe to use freely. You can iterate, change your mind, and refine your ideas without any risk of unintended changes to your project.
+Plan is still the right place to think things through — just don't treat it as an ironclad guarantee that nothing will change.
 
 ## The Build agent
 


### PR DESCRIPTION
This PR updates the agents lesson to note that Plan mode is an instruction to the model, not a hard sandbox. The agent may still occasionally make API calls or run commands that have side effects.

- Adds a caveat paragraph after the Plan agent description
- Replaces the "without any risk" claim with honest guidance
- Updates `agentInstructions` frontmatter so the quiz covers this nuance