### PR TITLE
docs: add /mcp command and config editing tips to tools lesson

### DIFF
--- a/src/content/lessons/09-tools.mdx
+++ b/src/content/lessons/09-tools.mdx
@@ -4,7 +4,7 @@ slug: tools
 description: "Extend OpenCode with external tools and MCP servers."
 order: 9
 quiz: true
-agentInstructions: "Cover these four topics: (1) what tools are — functions an AI can call to do things beyond generating text, sometimes called 'function calling' or 'tool use'; this is what makes OpenCode an agent rather than a chatbot, (2) what MCP is — Model Context Protocol, an open standard for connecting AI to external tools; two kinds of servers: local (runs on your machine, typically via npx) and remote (runs in the cloud, connected by URL), (3) public vs. authenticated servers — some MCP servers require no credentials and work immediately; others require an API token in your config or an OAuth browser flow to authenticate, (4) the context caveat — each MCP server adds tools to the context window, so it's worth being selective about how many you enable at once. After teaching and quizzing, verify completion by reading ~/.config/opencode/opencode.jsonc and confirming an 'mcp' block exists with at least one server entry. After marking the lesson complete, do NOT suggest moving on to the next lesson. Instead, tell the student: MCP servers are connected at startup, so they need to quit OpenCode Desktop and reopen it for the new server to be available — and they can move on to the next lesson after restarting."
+agentInstructions: "Cover these four topics: (1) what tools are — functions an AI can call to do things beyond generating text, sometimes called 'function calling' or 'tool use'; this is what makes OpenCode an agent rather than a chatbot, (2) what MCP is — Model Context Protocol, an open standard for connecting AI to external tools; two kinds of servers: local (runs on your machine, typically via npx) and remote (runs in the cloud, connected by URL); you can edit the config yourself or just ask OpenCode to add servers for you, (3) public vs. authenticated servers — some MCP servers require no credentials and work immediately; others require an API token in your config or an OAuth browser flow to authenticate, (4) the /mcp command and context — use /mcp in OpenCode to see configured servers and their connection status; good practice after installing a new server to confirm it's connected and authenticated; also note that each MCP server adds tools to the context window, so be selective about how many you enable. After teaching and quizzing, verify completion by reading ~/.config/opencode/opencode.jsonc and confirming an 'mcp' block exists with at least one server entry. After marking the lesson complete, do NOT suggest moving on to the next lesson. Instead, tell the student: MCP servers are connected at startup, so they need to quit OpenCode Desktop and reopen it for the new server to be available — and they can move on to the next lesson after restarting."
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'
@@ -35,7 +35,7 @@ OpenCode comes with built-in tools for things like reading files, editing code, 
 
 Let's install a local MCP server that fetches live weather data from [Open-Meteo](https://open-meteo.com) — a free, public weather API with no account or API key required.
 
-Ask OpenCode to add the following to your `~/.config/opencode/opencode.jsonc`:
+Even though MCP servers are managed in the global OpenCode config, you don't have to edit the file yourself — you can just ask OpenCode to do it. Try asking it to add the following to your `~/.config/opencode/opencode.jsonc`:
 
 ```jsonc
 "mcp": {
@@ -49,6 +49,10 @@ Ask OpenCode to add the following to your `~/.config/opencode/opencode.jsonc`:
 This tells OpenCode to start the `open-meteo-mcp-server` package via `npx` each time it launches. The server runs locally on your machine and connects to the Open-Meteo API when a weather tool is called.
 
 **This requires Node.js 22 or later.** If you don't have it installed, ask OpenCode to help you install it for your operating system.
+
+## Check with /mcp
+
+After adding a server, type `/mcp` in OpenCode to see a list of your configured MCP servers and their connection status. This is a good habit — pop it open after installing a new server to confirm it's connected and, if needed, authenticated.
 
 ## Restart OpenCode
 


### PR DESCRIPTION
This PR updates the tools lesson with two additions:

- Adds a "Check with /mcp" section teaching students to use the `/mcp` command to verify server connection status after installing a new MCP server.
- Clarifies that students can ask OpenCode to edit the global config for them rather than editing it manually.
- Updates `agentInstructions` to cover the `/mcp` command and the "ask OpenCode to edit config" workflow in the quiz flow.