### PR TITLE
fix: add global file safety instructions to prevent overwriting student files

### DIFF
--- a/src/lib/file-safety-instructions.ts
+++ b/src/lib/file-safety-instructions.ts
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Shared file safety instructions appended to every lesson's agentInstructions.
+ * Prevents the agent from overwriting the student's existing config files.
+ * Injected at the API layer so individual lesson MDX files don't need to repeat these rules.
+ */
+export const FILE_SAFETY_INSTRUCTIONS = `CRITICAL — file safety rules for every lesson: Before modifying any file on the student's machine, always read it first. If the file already exists, create a backup by copying it to a .bak file with a timestamp suffix (e.g. opencode.jsonc.bak.2026-04-06T12-00-00) before making any changes. Never overwrite or replace a file wholesale — merge the required changes into the existing content, preserving all settings, comments, and structure the student already has. If you created a backup, tell the student where to find it. These rules apply to config files (opencode.jsonc, opencode.json), instruction files (AGENTS.md), command files, and any other file you are asked to create or modify.`;

--- a/src/pages/api/lessons/[slug].ts
+++ b/src/pages/api/lessons/[slug].ts
@@ -4,6 +4,7 @@
 
 import { getCollection } from "astro:content";
 import type { APIRoute } from "astro";
+import { FILE_SAFETY_INSTRUCTIONS } from "../../../lib/file-safety-instructions";
 import { mdxToProse } from "../../../lib/mdx-to-prose";
 import { QUIZ_INSTRUCTIONS } from "../../../lib/quiz-instructions";
 
@@ -32,9 +33,10 @@ export const GET: APIRoute = async ({ params, request }) => {
 		});
 	}
 
-	const rawInstructions = lesson.data.quiz
+	let rawInstructions = lesson.data.quiz
 		? `${lesson.data.agentInstructions}\n\n${QUIZ_INSTRUCTIONS}`
 		: lesson.data.agentInstructions;
+	rawInstructions += `\n\n${FILE_SAFETY_INSTRUCTIONS}`;
 	const agentInstructions = rawInstructions.replaceAll("{origin}", origin);
 
 	const result = {

--- a/src/pages/api/lessons/index.ts
+++ b/src/pages/api/lessons/index.ts
@@ -4,6 +4,7 @@
 
 import { getCollection } from "astro:content";
 import type { APIRoute } from "astro";
+import { FILE_SAFETY_INSTRUCTIONS } from "../../../lib/file-safety-instructions";
 import { mdxToProse } from "../../../lib/mdx-to-prose";
 import { QUIZ_INSTRUCTIONS } from "../../../lib/quiz-instructions";
 
@@ -24,9 +25,10 @@ export const GET: APIRoute = async ({ request }) => {
 	);
 
 	const result = lessons.map((lesson) => {
-		const rawInstructions = lesson.data.quiz
+		let rawInstructions = lesson.data.quiz
 			? `${lesson.data.agentInstructions}\n\n${QUIZ_INSTRUCTIONS}`
 			: lesson.data.agentInstructions;
+		rawInstructions += `\n\n${FILE_SAFETY_INSTRUCTIONS}`;
 		const agentInstructions = rawInstructions.replaceAll("{origin}", origin);
 
 		return {


### PR DESCRIPTION
This PR adds a shared `FILE_SAFETY_INSTRUCTIONS` constant that the API layer appends to every lesson's `agentInstructions`. It tells the agent to always read files before modifying them, create timestamped backups of existing files, and merge changes instead of replacing files wholesale.

Changes:
- `src/lib/file-safety-instructions.ts` — new shared constant with the backup + merge rules
- `src/pages/api/lessons/index.ts` and `[slug].ts` — append the file safety block to all lessons
- `03-configuration.mdx` — remove the now-redundant "IMPORTANT: do not overwrite" text (the global instructions cover it)
- `04-permissions.mdx` — rewrite the student-facing prose from "replace the contents" to "update the `permission` block", showing only the permission fragment instead of a full replacement config

Closes #50