### PR TITLE
docs: default config to plan mode with defensive bash permissions

### DIFF
--- a/src/content/lessons/02-interview.mdx
+++ b/src/content/lessons/02-interview.mdx
@@ -52,7 +52,7 @@ agentInstructions: |
 
   Then briefly acknowledge their answers in a friendly way, referencing their preferences (e.g. "Got it — you're a Builder who prefers hands-on learning with concise explanations. I'll keep that in mind for the rest of the course."). If they skipped everything, that's fine — just say you'll teach at a general level.
 
-  Note: This lesson happens before the student has configured generous permissions, so they may need to manually approve a few permission prompts from OpenCode (like allowing network requests). If the student asks about this, reassure them it's normal and will be addressed in the Configuration lesson.
+  Note: This lesson happens before the student has configured permissions, so they may need to manually approve a few permission prompts from OpenCode (like allowing network requests). If the student asks about this, reassure them it's normal and will be addressed in the Configuration lesson.
 
   Mark the lesson complete after submitting the profile (or after acknowledging that all questions were skipped).
 ---

--- a/src/content/lessons/03-configuration.mdx
+++ b/src/content/lessons/03-configuration.mdx
@@ -4,7 +4,7 @@ slug: configuration
 description: "Create a global configuration file for OpenCode."
 order: 3
 quiz: true
-agentInstructions: "Cover these four topics: (1) what the global config file is and why it applies to all OpenCode sessions across every project on the machine, (2) where the config file lives — ~/.config/opencode/opencode.jsonc on macOS/Linux, C:\\Users\\<Name>\\.config\\opencode\\opencode.jsonc on Windows, (3) what \"permission\": {\"*\": \"allow\"} does — it lets OpenCode perform all actions without asking, (4) that the \"instructions\" array lets OpenCode load extra context at session start, and that we are adding the student's personal OpenCode School instructions URL so OpenCode always knows who they are — the URL is {origin}/api/instructions/{studentId} (substituting the student's actual ID). After teaching and quizzing, verify completion by reading ~/.config/opencode/opencode.jsonc (or ~/.config/opencode/opencode.json if the .jsonc file does not exist) and confirming it contains both \"permission\": {\"*\": \"allow\"} and an \"instructions\" array that includes the student's personal OpenCode School instructions URL ({origin}/api/instructions/{studentId} with their actual student ID). Either file extension is acceptable. IMPORTANT: If a global config file already exists, do not overwrite it — read it, confirm the required permission setting exists, and add the \"instructions\" array only if it does not already contain the student's OpenCode School URL. Config changes require restarting OpenCode to take effect. After verifying, instruct the student to quit OpenCode Desktop so the new config takes effect next time they open it."
+agentInstructions: "Cover these four topics: (1) what the global config file is and why it applies to all OpenCode sessions across every project on the machine, (2) where the config file lives — ~/.config/opencode/opencode.jsonc on macOS/Linux, C:\\Users\\<Name>\\.config\\opencode\\opencode.jsonc on Windows, (3) what \"default_agent\": \"plan\" does — it starts every new session in Plan mode, which is read-only and safe; the student can switch to Build mode when they're ready to make changes, (4) permission basics and the instructions URL — \"*\": \"allow\" lets most actions through automatically, but the bash object adds \"ask\" rules for destructive commands like rm and rmdir so OpenCode pauses before running them; the \"instructions\" array loads the student's personal OpenCode School URL ({origin}/api/instructions/{studentId}) so OpenCode always knows who they are. After teaching and quizzing, verify completion by reading ~/.config/opencode/opencode.jsonc (or ~/.config/opencode/opencode.json if the .jsonc file does not exist) and confirming it contains \"default_agent\": \"plan\", a \"permission\" object with \"*\": \"allow\" plus at least one \"ask\" rule inside a bash object (e.g. \"rm *\": \"ask\"), and an \"instructions\" array that includes the student's personal OpenCode School instructions URL ({origin}/api/instructions/{studentId} with their actual student ID). Either file extension is acceptable. IMPORTANT: If a global config file already exists, do not overwrite it — read it, merge in any missing settings, and add the \"instructions\" array only if it does not already contain the student's OpenCode School URL. Config changes require restarting OpenCode to take effect. After verifying, instruct the student to quit OpenCode Desktop so the new config takes effect next time they open it."
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'
@@ -13,7 +13,7 @@ Each lesson has a prompt you can copy and paste into OpenCode. The prompt includ
 
 In this lesson, you'll create a **global configuration file** that will apply to every OpenCode session across every project on your machine. It includes settings like which AI [model](/glossary#model) to use, what [permissions](/glossary#permissions) to grant, and how the [agent](/glossary#agent) should behave. You'll tweak your global configuration over time to make OpenCode work exactly the way you want.
 
-**If you've already created a global config file, that's great — it won't be overwritten.** Just make sure it contains `"permission": { "*": "allow" }` and you're all set.
+**If you've already created a global config file, that's great — it won't be overwritten.** OpenCode will merge in any missing settings.
 
 <AgentPrompt title="Configuration" />
 
@@ -74,11 +74,21 @@ Here's what your config file will look like:
   // Points to OpenCode's config schema — enables autocomplete in VS Code
   "$schema": "https://opencode.ai/config.json",
 
+  // Start new sessions in Plan mode instead of Build mode.
+  // Plan is read-only — it can read files and discuss your project,
+  // but won't make any changes until you switch to Build.
+  "default_agent": "plan",
+
   // Permissions control what OpenCode can do without asking first.
-  // "*": "allow" grants permission for everything automatically.
-  // We'll tighten this up in the next lesson.
+  // "*": "allow" lets most actions through automatically, but the
+  // bash rules below add guardrails for destructive commands.
   "permission": {
-    "*": "allow"
+    "*": "allow",
+    "bash": {
+      "*": "allow",
+      "rm *": "ask",
+      "rmdir *": "ask"
+    }
   },
 
   // Instructions are URLs or file paths that OpenCode loads at the start of
@@ -90,7 +100,11 @@ Here's what your config file will look like:
 }
 ```
 
-We'll substitute your actual student ID when we create the file. The instructions URL lets OpenCode fetch your school enrollment at the start of every session, so it has your student profile on hand even when you're working on something unrelated.
+We'll substitute your actual student ID when we create the file. A few things to note:
+
+- `"default_agent": "plan"` means every new session starts in [Plan mode](/glossary#agent) — a read-only agent that can read your files and discuss your project but won't make any changes. When you're ready to act, you switch to Build. We'll cover this in detail in the [Agents](/agents) lesson.
+- The `"bash"` block inside `"permission"` adds safety guardrails for shell commands. Most commands run automatically, but `rm` (delete files) and `rmdir` (remove directories) will pause and ask for your approval first. We'll add more permission rules in the next lesson.
+- The instructions URL lets OpenCode fetch your school enrollment at the start of every session, so it has your student profile on hand even when you're working on something unrelated.
 
 ## Restart OpenCode
 
@@ -117,4 +131,4 @@ document.addEventListener("DOMContentLoaded", function() {
 });
 `}</script>
 
-The config also supports models, MCP servers, custom commands, themes, and keybinds — we'll get to those in later lessons. Full reference: [OpenCode config docs](https://opencode.ai/docs/config/).
+The config also supports models, MCP servers, custom commands, agents, themes, and keybinds — we'll get to those in later lessons. Full reference: [OpenCode config docs](https://opencode.ai/docs/config/).

--- a/src/content/lessons/04-permissions.mdx
+++ b/src/content/lessons/04-permissions.mdx
@@ -4,14 +4,14 @@ slug: permissions
 description: "Control what OpenCode can and can't do without asking."
 order: 4
 quiz: true
-agentInstructions: "Cover these four topics: (1) why granular permissions are better than a bare wildcard — they give you safety guardrails without constant interruptions, (2) the three permission levels: allow (runs immediately), ask (pauses for approval), and deny (blocked entirely), (3) how to write a granular rule — e.g. nesting a pattern like \"rm *\": \"ask\" inside the bash object, (4) the external_directory permission — it controls access to paths outside the project working directory, defaults to \"ask\", and can be configured with path patterns using ~ or $HOME (e.g. \"~/projects/**\": \"allow\"). After teaching and quizzing, verify completion by reading ~/.config/opencode/opencode.jsonc and confirming the \"permission\" object has at least one granular rule beyond a bare wildcard (e.g. a rule for rm, rmdir, or mv inside the bash object)."
+agentInstructions: "Cover these four topics: (1) the three permission levels — allow (runs immediately), ask (pauses for approval), and deny (blocked entirely); the student already has ask rules for rm and rmdir from the Configuration lesson, so build on that foundation, (2) git-specific guardrails — adding \"git push *\": \"ask\" and \"git checkout *\": \"ask\" inside the bash object to prevent accidental pushes to remote repos and discarding uncommitted changes without confirmation, (3) the external_directory permission — it controls access to paths outside the project working directory, defaults to \"ask\", and can be configured with path patterns using ~ or $HOME (e.g. \"~/projects/**\": \"allow\"), (4) per-project permissions — the student can create .opencode/opencode.jsonc in any project directory to override their global permissions for that project; useful for tightening or loosening rules in specific repos. After teaching and quizzing, verify completion by reading ~/.config/opencode/opencode.jsonc and confirming the bash object has at least one new granular rule beyond what was set up in the Configuration lesson — e.g. a \"git push *\": \"ask\" or \"git checkout *\": \"ask\" rule."
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'
 
 <AgentPrompt title="Permissions" />
 
-In the previous lesson, you set `"*": "allow"` in your config — which means OpenCode can do anything without asking for permission. That's convenient for learning, but in practice you'll want more control over what happens on your machine.
+In the Configuration lesson, you set up basic permissions with `"ask"` rules for destructive commands like `rm` and `rmdir`. Now let's go further — adding guardrails for Git operations and learning about per-project overrides.
 
 ## The three permission levels
 
@@ -23,39 +23,54 @@ Every action OpenCode takes is governed by one of three rules:
 | `ask`   | OpenCode pauses and asks for your approval before proceeding |
 | `deny`  | The action is blocked entirely                               |
 
-When OpenCode asks for permission, you'll see three options:
+You've already seen `allow` and `ask` in your config. The `deny` level blocks an action outright — OpenCode won't even attempt it. Use `deny` for things you never want to happen automatically, like `chmod` or `chown`.
+
+## When OpenCode asks for permission
+
+When OpenCode hits an `ask` rule, it pauses and shows you three options:
 
 - **Allow Once** — approve this specific action, just this time
 - **Always** — approve this action and similar ones for the rest of the session
 - **Reject** — deny this specific action
 
-## Tighten your permissions
+This is the flow you'll see whenever OpenCode tries to run `rm`, `rmdir`, or any other command gated by an `ask` rule.
 
-Let's edit your global config to add some safety guardrails. Ask OpenCode to replace the contents of `~/.config/opencode/opencode.jsonc` with:
+## Add Git guardrails
+
+Destructive file commands aren't the only thing worth guarding. Git operations can be just as consequential — an accidental `git push` to the wrong branch or a `git checkout` that discards uncommitted work. Let's add rules for those.
+
+Update the `bash` block in your global config:
 
 ```jsonc
+"bash": {
+  "*": "allow",
+  "rm *": "ask",
+  "rmdir *": "ask",
+  "git push *": "ask",
+  "git checkout *": "ask"
+}
+```
+
+Now OpenCode will pause before pushing to a remote or checking out a branch, giving you a chance to confirm.
+
+## Per-project permissions
+
+Your global config applies to every project, but sometimes you need different rules for different repos. You can create a `.opencode/opencode.jsonc` file in any project directory to override your global permissions for that project.
+
+For example, if you're working on a project where you trust the workflow and want OpenCode to push freely:
+
+```jsonc
+// .opencode/opencode.jsonc (in the project root)
 {
-  "$schema": "https://opencode.ai/config.json",
   "permission": {
-    // Allow most things by default
-    "*": "allow",
-    // But ask before running destructive shell commands
     "bash": {
-      "*": "allow",
-      "rm *": "ask",
-      "rmdir *": "ask",
-      "mv *": "ask"
-    },
-    // Ask before accessing files outside the project directory
-    "external_directory": "ask"
+      "git push *": "allow"
+    }
   }
 }
 ```
 
-Save the file. This config:
-
-- Allows most actions automatically (reading files, editing code, running safe commands)
-- Asks for your permission before deleting files (`rm`), removing directories (`rmdir`), or moving/renaming files (`mv`)
+Project-level settings are layered on top of global ones — they override only the specific rules you set, leaving everything else unchanged.
 
 ## Working outside the project
 
@@ -80,4 +95,4 @@ Paths allowed via `external_directory` inherit the same tool defaults as your pr
 
 For the full list of permissions and pattern syntax, see the [permissions documentation](https://opencode.ai/docs/permissions/).
 
-Once you've saved your updated config with at least one granular permission rule (like `"rm *": "ask"`), this lesson is complete.
+Once you've added at least one new permission rule (like `"git push *": "ask"`) to your global config, this lesson is complete.

--- a/src/content/lessons/10-agents.mdx
+++ b/src/content/lessons/10-agents.mdx
@@ -4,7 +4,7 @@ slug: agents
 description: "Use Plan and Build agents to think before you act."
 order: 10
 quiz: true
-agentInstructions: "Cover these four topics: (1) what an agent means in OpenCode specifically — a specialized assistant configured for a particular task or workflow, distinct from the broader industry use of the word, (2) the Plan agent — conversational and read-only; it can read files and discuss the project but won't make any changes; use it to think out loud, explore options, and arrive at a clear plan — but note that Plan mode is not a hard sandbox and the agent may still occasionally run commands or make API calls that have side effects, (3) the Build agent — the implementation agent with full access to read, write, and run things; use this once you know what you want to do, (4) the recommended workflow — start in Plan to think things through safely, switch to Build when ready to implement; Plan is optional but a good habit especially for complex or unfamiliar tasks. After teaching and quizzing, verify completion by asking the student to describe when they'd use Plan vs. Build and confirm they understand that Plan is read-only by default but not a guaranteed sandbox, and that Build can make changes."
+agentInstructions: "Cover these four topics: (1) what an agent means in OpenCode specifically — a specialized assistant configured for a particular task or workflow, distinct from the broader industry use of the word, (2) the Plan agent — conversational and read-only; it can read files and discuss the project but won't make any changes; the student already set \"default_agent\": \"plan\" in the Configuration lesson so every new session starts here — but note that Plan mode is not a hard sandbox and the agent may still occasionally run commands or make API calls that have side effects, (3) the Build agent — the implementation agent with full access to read, write, and run things; switch to this when you know what you want to do, (4) the recommended workflow — since Plan is already the default, the student is already starting safe; the key skill is knowing when to switch to Build and being deliberate about it, especially for complex or unfamiliar tasks. After teaching and quizzing, verify completion by asking the student to describe when they'd use Plan vs. Build and confirm they understand that Plan is read-only by default but not a guaranteed sandbox, and that Build can make changes."
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'
@@ -18,6 +18,8 @@ OpenCode ships with two built-in agents: **Plan** and **Build**.
 ## The Plan agent
 
 Plan is a read-only conversational agent. It can read your files and discuss your project, but it won't make any changes. No files written, no commands run, nothing modified.
+
+You already set `"default_agent": "plan"` in your global config back in the [Configuration](/configuration) lesson, so every new session starts here. That's intentional — you think first, then act.
 
 That said, Plan mode is an instruction to the model, not a hard sandbox. Occasionally the agent may still make API calls or run commands that have side effects, so it's not a guaranteed protection against unintended changes.
 
@@ -42,11 +44,11 @@ Build is the implementation agent. It has full access — it can read files, wri
 
 ## The recommended workflow
 
-Plan is not required — you can go straight to Build for straightforward tasks. But for anything complex or unfamiliar, starting in Plan is a good habit. It gives you a chance to think out loud with the agent, catch problems early, and arrive at Build with a clear direction.
+Since Plan is your default, every session already starts safe. For quick, straightforward tasks you can switch straight to Build. But for anything complex or unfamiliar, staying in Plan first is a good habit. It gives you a chance to think out loud with the agent, catch problems early, and arrive at Build with a clear direction.
 
 A useful pattern:
 
-1. **Switch to Plan.** Describe what you want to accomplish.
+1. **Start in Plan.** Describe what you want to accomplish. (You're already here.)
 2. **Explore together.** Ask questions, consider options, refine the approach.
 3. **Switch to Build.** Tell it to implement what you planned.
 


### PR DESCRIPTION
This PR reworks the Configuration lesson (03) to set a more defensive default config, then updates downstream lessons to stay consistent.

## Configuration lesson (03)

- Adds `"default_agent": "plan"` so new sessions start in read-only Plan mode
- Adds `"rm *": "ask"` and `"rmdir *": "ask"` bash rules instead of a bare `"*": "allow"` wildcard
- Updates prose and agentInstructions to explain Plan mode and the bash guardrails

## Permissions lesson (04)

- Refocused away from rm/rmdir (now covered in Configuration) toward new topics:
  - Git guardrails: `"git push *": "ask"`, `"git checkout *": "ask"`
  - Per-project permissions via `.opencode/opencode.jsonc`
  - The `deny` permission level
- Preserves the `external_directory` section and "Working outside the project" content from #87
- Updates agentInstructions quiz topics to match

## Agents lesson (10)

- Acknowledges that Plan is already the student's default from lesson 3
- Merges with the sandbox caveat from #88
- Reframes the "recommended workflow" section around knowing when to switch to Build

## Interview lesson (02)

- Minor wording fix: "generous permissions" → "permissions" in agentInstructions