### PR TITLE
fix: hide enrolled indicator below lg breakpoint

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -667,7 +667,7 @@ const currentPath = Astro.url.pathname;
       </nav>
 
       <!-- Enrolled indicator (fixed top-right on desktop) -->
-      <div id="enrolled-indicator" class="hidden max-sm:!hidden fixed top-6 right-6 z-40">
+      <div id="enrolled-indicator" class="hidden max-lg:!hidden fixed top-6 right-6 z-40">
         <span class="text-xs font-mono text-gray-400 dark:text-stone-500">Enrolled as <span data-student-id class="text-gray-500 dark:text-stone-400"></span></span>
       </div>
 


### PR DESCRIPTION
This PR hides the "Enrolled as <id>" indicator at screen widths below the `lg` breakpoint (1024px). Previously it was only hidden below `sm` (640px), which left it visible and overlapping the hamburger menu between 640–1024px.

Changes `max-sm:!hidden` to `max-lg:!hidden` on the `#enrolled-indicator` div so its visibility aligns with the sidebar breakpoint.