### PR TITLE
fix: restore sidebar icon links

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -664,6 +664,51 @@ const currentPath = Astro.url.pathname;
             Disenroll
           </a>
         </div>
+        <div class="mt-6 pt-4 border-t border-gray-200 dark:border-stone-800 flex items-center gap-5 px-3">
+          <!-- Created and sponsored by Cloudflare -->
+          <div class="relative group">
+            <a href="https://developers.cloudflare.com/directory/" target="_blank" rel="noopener noreferrer" class="block text-gray-400 dark:text-stone-600 hover:text-orange-400 dark:hover:text-orange-400 transition-colors" aria-label="Created and sponsored by Cloudflare">
+              <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path d="M16.5088 16.8447c.1475-.5068.0908-.9707-.1553-1.3154-.2246-.3164-.6045-.499-1.0615-.5205l-8.6592-.1123a.1559.1559 0 0 1-.1333-.0713c-.0283-.042-.0351-.0986-.021-.1553.0278-.084.1123-.1484.2036-.1562l8.7359-.1123c1.0351-.0489 2.1601-.8868 2.5537-1.9136l.499-1.3013c.0215-.0561.0293-.1128.0147-.168-.5625-2.5463-2.835-4.4453-5.5499-4.4453-2.5039 0-4.6284 1.6177-5.3876 3.8614-.4927-.3658-1.1187-.5625-1.794-.499-1.2026.119-2.1665 1.083-2.2861 2.2856-.0283.31-.0069.6128.0635.894C1.5683 13.171 0 14.7754 0 16.752c0 .1748.0142.3515.0352.5273.0141.083.0844.1475.1689.1475h15.9814c.0909 0 .1758-.0645.2032-.1553l.12-.4268zm2.7568-5.5634c-.0771 0-.1611 0-.2383.0112-.0566 0-.1054.0415-.127.0976l-.3378 1.1744c-.1475.5068-.0918.9707.1543 1.3164.2256.3164.6055.498 1.0625.5195l1.8437.1133c.0557 0 .1055.0263.1329.0703.0283.043.0351.1074.0214.1562-.0283.084-.1132.1485-.204.1553l-1.921.1123c-1.041.0488-2.1582.8867-2.5527 1.914l-.1406.3585c-.0283.0713.0215.1416.0986.1416h6.5977c.0771 0 .1474-.0489.169-.126.1122-.4082.1757-.837.1757-1.2803 0-2.6025-2.125-4.727-4.7344-4.727"/>
+              </svg>
+            </a>
+            <span class="pointer-events-none absolute bottom-full left-0 mb-2 whitespace-nowrap rounded px-2 py-1 text-xs bg-gray-800 dark:bg-stone-700 text-white opacity-0 group-hover:opacity-100 transition-opacity">Created and sponsored by Cloudflare</span>
+          </div>
+          <!-- Built with OpenCode -->
+          <div class="relative group">
+            <a href="https://opencode.ai" target="_blank" rel="noopener noreferrer" class="block text-gray-400 dark:text-stone-600 hover:text-gray-600 dark:hover:text-stone-400 transition-colors opacity-60" aria-label="Built with OpenCode">
+              <!-- light mode icon -->
+              <svg class="dark:hidden w-5 h-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path d="M10 17H4V10H10V17Z" fill="#CFCECD"/>
+                <path d="M10 7H4V17H10V7ZM13 20H1V4H13V20Z" fill="#656363"/>
+              </svg>
+              <!-- dark mode icon -->
+              <svg class="hidden dark:block w-5 h-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path d="M10 17H4V10H10V17Z" fill="#4B4646"/>
+                <path d="M10 7H4V17H10V7ZM13 20H1V4H13V20Z" fill="#B7B1B1"/>
+              </svg>
+            </a>
+            <span class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded px-2 py-1 text-xs bg-gray-800 dark:bg-stone-700 text-white opacity-0 group-hover:opacity-100 transition-opacity">Built with OpenCode</span>
+          </div>
+          <!-- Open source on GitHub -->
+          <div class="relative group">
+            <a href="https://github.com/opencodeschool/opencode.school" target="_blank" rel="noopener noreferrer" class="block text-gray-400 dark:text-stone-600 hover:text-gray-600 dark:hover:text-stone-400 transition-colors" aria-label="Open source on GitHub">
+              <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.342-3.369-1.342-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+              </svg>
+            </a>
+            <span class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded px-2 py-1 text-xs bg-gray-800 dark:bg-stone-700 text-white opacity-0 group-hover:opacity-100 transition-opacity">Open source on GitHub</span>
+          </div>
+          <!-- OpenCode support community (Discord) -->
+          <div class="relative group">
+            <a href="https://opencode.ai/discord" target="_blank" rel="noopener noreferrer" class="block text-gray-400 dark:text-stone-600 hover:text-gray-600 dark:hover:text-stone-400 transition-colors" aria-label="OpenCode support community on Discord">
+              <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+              </svg>
+            </a>
+            <span class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded px-2 py-1 text-xs bg-gray-800 dark:bg-stone-700 text-white opacity-0 group-hover:opacity-100 transition-opacity">OpenCode support community</span>
+          </div>
+        </div>
       </nav>
 
       <!-- Enrolled indicator (fixed top-right on desktop) -->


### PR DESCRIPTION
This PR restores the four icon links (Cloudflare, OpenCode, GitHub, Discord) at the bottom of the sidebar. They were removed in #77 when the /about page was added.

Closes #81