### PR TITLE
fix: remove enrolled-as indicator from top-right corner

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -514,11 +514,6 @@ const currentPath = Astro.url.pathname;
 
         updateEnrolledIndicator() {
           const id = this.getStudentId();
-          const el = document.getElementById("enrolled-indicator");
-          if (el && id) {
-            el.querySelector("[data-student-id]").textContent = id;
-            el.classList.remove("hidden");
-          }
           const disenrollLink = document.getElementById("sidebar-disenroll-link");
           if (disenrollLink && id) {
             disenrollLink.classList.remove("hidden");
@@ -710,11 +705,6 @@ const currentPath = Astro.url.pathname;
           </div>
         </div>
       </nav>
-
-      <!-- Enrolled indicator (fixed top-right on desktop) -->
-      <div id="enrolled-indicator" class="hidden max-lg:!hidden fixed top-6 right-6 z-40">
-        <span class="text-xs font-mono text-gray-400 dark:text-stone-500">Enrolled as <span data-student-id class="text-gray-500 dark:text-stone-400"></span></span>
-      </div>
 
       <!-- Main content -->
       <main class="flex-1 min-w-0 p-6 lg:p-12 max-w-3xl">


### PR DESCRIPTION
This PR removes the fixed-position "Enrolled as <id>" badge from the top-right corner of the page. The homepage student ID card and agent prompt text are unchanged.

The `updateEnrolledIndicator()` function is kept since it still handles showing the disenroll link in the sidebar.