### PR TITLE
docs: add lesson 14 — Plugins

### DIFF
--- a/src/content/lessons/10-plugins.mdx
+++ b/src/content/lessons/10-plugins.mdx
@@ -2,7 +2,7 @@
 title: "Plugins"
 slug: plugins
 description: "Extend OpenCode with plugins that add tools, hook into events, and integrate external services."
-order: 14
+order: 10
 quiz: true
 agentInstructions: "Cover these four topics: (1) what plugins are — JavaScript or TypeScript modules that extend OpenCode by hooking into events, adding custom tools, or integrating external services; they go beyond MCP servers (covered in the Tools lesson) by letting you modify OpenCode's behavior itself rather than just exposing external tools; reference the Tools lesson so the student sees the progression, (2) where plugins live — two scopes: project-level in .opencode/plugins/ and global in ~/.config/opencode/plugins/; can also install npm packages via the plugin array in opencode.json; dependencies go in a package.json in the same config directory and OpenCode runs bun install automatically at startup, (3) what plugins can do — subscribe to lifecycle events like session.idle or tool.execute.before; add custom tools using the tool() helper from @opencode-ai/plugin with Zod schemas for arguments; inject environment variables; modify tool behavior with before/after hooks; plugins can also ship companion skills that inject workflow guidance into the agent prompt, (4) installing a real plugin — walk through installing the Replicate plugin as a hands-on example: first get a Replicate API token from replicate.com/account/api-tokens, add export REPLICATE_API_TOKEN=r8_your_token_here to their shell profile (.bashrc or .zshrc), then run the quick-install script with curl -sSL https://raw.githubusercontent.com/lucataco/replicate-opencode-plugin/main/install.sh | bash from the project root, which downloads the plugin, a companion skill, and a package.json into the .opencode/ directory; after restarting OpenCode, verify by asking 'What is my Replicate username?' and confirming the agent calls replicate_whoami and returns account info. After teaching and quizzing, verify completion by reading .opencode/plugins/replicate.ts and confirming it exists. After marking the lesson complete, do NOT suggest moving on to the next lesson. Instead, tell the student: plugins are loaded at startup, so they need to quit OpenCode Desktop and reopen it for the new plugin to be fully available — and they can move on to the next lesson after restarting."
 ---
@@ -120,7 +120,7 @@ The agent should call the `replicate_whoami` tool and return your account info. 
 
 Now try something more interesting:
 
-> Generate an image of a cat in a spacesuit
+> Generate a video of a cat in a spacesuit
 
 Watch as the agent searches for an image generation model, checks its input schema, runs a prediction, and presents the result — all through the plugin's tools, guided by the companion skill.
 

--- a/src/content/lessons/11-agents.mdx
+++ b/src/content/lessons/11-agents.mdx
@@ -2,7 +2,7 @@
 title: "Agents"
 slug: agents
 description: "Use Plan and Build agents to think before you act."
-order: 10
+order: 11
 quiz: true
 agentInstructions: "Cover these four topics: (1) what an agent means in OpenCode specifically — a specialized assistant configured for a particular task or workflow, distinct from the broader industry use of the word, (2) the Plan agent — conversational and read-only; it can read files and discuss the project but won't make any changes; the student already set \"default_agent\": \"plan\" in the Configuration lesson so every new session starts here — but note that Plan mode is not a hard sandbox and the agent may still occasionally run commands or make API calls that have side effects, (3) the Build agent — the implementation agent with full access to read, write, and run things; switch to this when you know what you want to do, (4) the recommended workflow — since Plan is already the default, the student is already starting safe; the key skill is knowing when to switch to Build and being deliberate about it, especially for complex or unfamiliar tasks. After teaching and quizzing, verify completion by asking the student to describe when they'd use Plan vs. Build and confirm they understand that Plan is read-only by default but not a guaranteed sandbox, and that Build can make changes."
 ---

--- a/src/content/lessons/12-sessions.mdx
+++ b/src/content/lessons/12-sessions.mdx
@@ -2,7 +2,7 @@
 title: "Sessions"
 slug: sessions
 description: "Manage and resume conversations with Sessions."
-order: 11
+order: 12
 quiz: true
 agentInstructions: "Cover these four topics: (1) what a session is — an individual conversation with OpenCode; each session has its own history and context; a single project can have many sessions, (2) starting a new session — type /new in the prompt (works in both Desktop and TUI) or use the New Session button in the Desktop left sidebar, (3) sessions persist — conversation history is saved to disk, so you can resume any previous session even after quitting and restarting OpenCode, (4) sharing — /share generates a public link at opncd.ai/s/<id> that anyone with the link can view; /unshare removes it; three sharing modes: manual (default, share on demand), auto (every session shared automatically), disabled (sharing turned off entirely). After teaching and quizzing, run 'opencode session list' yourself to get all sessions, pick one that looks interesting, run 'opencode export <sessionID>' on it, and give the student a brief summary of what was being worked on in that session. Then mark the lesson complete."
 ---

--- a/src/content/lessons/13-images.mdx
+++ b/src/content/lessons/13-images.mdx
@@ -2,7 +2,7 @@
 title: "Images"
 slug: images
 description: "Share images and screenshots with OpenCode."
-order: 12
+order: 13
 quiz: true
 agentInstructions: "Cover these four topics: (1) what vision capability is — some models can interpret images pasted into the conversation; they can describe photos, extract text from screenshots, and read UI details including layout, spacing, typography, and color, (2) how to add images — drag and drop an image into the OpenCode window, or paste with Cmd+V (Mac) or Ctrl+V (Windows/Linux); images are sent as part of the conversation just like text, (3) which models support vision — all Claude models (Haiku, Sonnet, Opus), all GPT-4 and GPT-5 family models, and Gemini models all have confirmed vision support; Kimi K2.5 via OpenCode Go is the most affordable confirmed vision model; the free Zen models (Big Pickle, MiMo, Nemotron, MiniMax Free) do not have confirmed vision support — if a model doesn't acknowledge your image, switch to a vision-capable model, (4) what vision is useful for — pasting a screenshot of an inspiring UI to replicate, pasting a screenshot of a bug to help diagnose it, pasting a design mockup to implement; the model can interpret colors, spacing, typography, and content from images. After teaching and quizzing, verify completion by confirming the student has pasted or attached an image and received a response that references its contents."
 ---

--- a/src/content/lessons/14-workspaces.mdx
+++ b/src/content/lessons/14-workspaces.mdx
@@ -2,7 +2,7 @@
 title: "Workspaces"
 slug: workspaces
 description: "Run multiple parallel tasks on the same project without file conflicts."
-order: 13
+order: 14
 quiz: true
 agentInstructions: "Cover these four topics: (1) what workspaces are — isolated copies of project files on their own Git branch, letting you work on multiple tasks in parallel without file conflicts; this is a Desktop-only feature that requires the project to be a Git repository, (2) the problem they solve — running multiple sessions on the same project simultaneously risks one session overwriting another's changes; workspaces prevent this by giving each task its own complete copy of the project files, (3) how to create one — right-click the project in the OpenCode Desktop left sidebar, select 'Enable Workspaces', then click 'New Workspace' to create an isolated copy; each workspace gets an auto-generated name and its own branch, (4) what happens under the hood — each workspace creates a branch named opencode/<name> and checks it out to a separate directory on disk; when the work is done, the branch can be merged back into the main branch via Git like any other branch. After teaching and quizzing, verify completion by confirming the student can describe what workspaces are for and how to create one. No file-system check is needed."
 ---


### PR DESCRIPTION
## Summary

- Adds new **Plugins** lesson teaching students how to extend OpenCode with JavaScript/TypeScript plugins
- Covers plugin locations (project-level vs global vs npm), event hooks, custom tools via the `tool()` helper, and companion skills
- Includes a hands-on exercise installing the [Replicate plugin](https://github.com/lucataco/replicate-opencode-plugin) via its quick-install script
- Follows the existing quiz lesson format: four numbered topics in `agentInstructions`, file-system verification (`.opencode/plugins/replicate.ts`), and restart-after-install pattern matching the Tools lesson

## Lesson reorder

Moves Plugins to lesson **10** (right after Tools) to complete the extensibility arc:

**Commands (7) → Skills (8) → Tools (9) → Plugins (10)**

Shifted lessons (content and slugs unchanged):
- Agents: 10 → 11
- Sessions: 11 → 12
- Images: 12 → 13
- Workspaces: 13 → 14

Only frontmatter `order` fields and filename prefixes changed. Slugs, URLs, and content are untouched — the lesson API discovers lessons dynamically from the content collection.