### PR TITLE
docs: prepare repo for open-sourcing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .astro/
 .wrangler/
 .env
+.dev.vars

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
+See [README.md](README.md) for setup instructions and [CONTRIBUTING.md](CONTRIBUTING.md) for how to contribute.
+
 ## Project overview
 
 OpenCode School (opencode.school) is an interactive course that teaches people how to use OpenCode. Built with Astro 6, deployed to Cloudflare Workers, with student progress tracked via Cloudflare KV.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at https://github.com/opencodeschool/opencode.school/issues. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing to OpenCode School
+
+Thanks for your interest in contributing! This project is an open-source learning resource for [OpenCode](https://opencode.ai), and we welcome contributions of all kinds: lesson content, bug fixes, design improvements, and more.
+
+## Before you start
+
+- Search [existing issues](https://github.com/opencodeschool/opencode.school/issues) before opening a new one to avoid duplicates.
+- Open or link to an issue before submitting a pull request, so there's a place to discuss the change.
+
+## Development setup
+
+See the [README](README.md) for instructions on cloning the repo and starting the dev server.
+
+## Making changes
+
+1. Fork the repo and create a branch from `main`.
+2. Make your changes.
+3. Run `script/lint` to check for linting errors.
+4. Run `script/test` to make sure tests pass.
+5. Open a pull request against `main`.
+
+## Architecture
+
+See [AGENTS.md](AGENTS.md) for details on the project structure, lesson authoring guidelines, API endpoints, and content conventions. This is useful context whether you're writing code or lesson content.
+
+## Code of conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). By participating, you agree to uphold it.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,40 @@
 # OpenCode School
 
-A free, self-paced course for learning [OpenCode](https://opencode.ai), the open-source AI coding agent.
+A free, self-paced course for learning [OpenCode](https://opencode.ai), the open-source AI coding agent. Built with [Astro](https://astro.build) and deployed to [Cloudflare Workers](https://workers.cloudflare.com).
 
 https://opencode.school
 
-See [AGENTS.md](AGENTS.md) for architecture details and AI agent instructions.
+## Getting started
 
-## Development
+You'll need [Node.js](https://nodejs.org) (v20 or later) installed.
 
 ```sh
-script/dev    # start dev server
-script/build  # build for production
-script/lint   # run linter
-script/deploy # build + deploy to Cloudflare
+git clone https://github.com/opencodeschool/opencode.school.git
+cd opencode.school
+npm install
+script/dev     # start the dev server
 ```
+
+Other useful scripts:
+
+```sh
+script/build   # build for production
+script/test    # run tests
+script/lint    # run linter
+```
+
+## Deploying
+
+The site is deployed to Cloudflare Workers via GitHub Actions on push to `main`. If you fork the repo and want to deploy your own instance, you'll need a Cloudflare account with a KV namespace and R2 bucket. See `wrangler.jsonc` for details. Local development does not require a Cloudflare account.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get involved.
+
+## Architecture
+
+See [AGENTS.md](AGENTS.md) for architecture details, content authoring guidelines, and AI agent instructions.
+
+## License
+
+[Apache 2.0](LICENSE)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,16 @@
   "name": "opencode-school",
   "type": "module",
   "version": "0.0.1",
+  "description": "A free, self-paced course for learning OpenCode, the open-source AI coding agent",
   "license": "Apache-2.0",
+  "homepage": "https://opencode.school",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opencodeschool/opencode.school.git"
+  },
+  "bugs": {
+    "url": "https://github.com/opencodeschool/opencode.school/issues"
+  },
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,6 +6,9 @@
   "assets": {
     "directory": "./dist"
   },
+  // The R2 bucket and KV namespace below are for the production deployment.
+  // You only need these if you're deploying to your own Cloudflare account.
+  // Local dev (`script/dev`) works fine without them.
   "r2_buckets": [
     {
       "binding": "ASSETS_BUCKET",


### PR DESCRIPTION
This PR prepares the repo for open-sourcing by adding standard community docs and cleaning up config.

- Expanded README with setup instructions, contributing link, and license
- Added CONTRIBUTING.md with issue-first workflow guidelines
- Added CODE_OF_CONDUCT.md (Contributor Covenant v2.1)
- Cross-linked README, CONTRIBUTING, and AGENTS.md
- Added `repository`, `homepage`, `bugs`, and `description` to package.json
- Added `.dev.vars` to .gitignore
- Added comments to wrangler.jsonc noting that the KV namespace and R2 bucket are only needed for deployment, not local dev

After this merges, the repo can be flipped to public with:

```
gh repo edit opencodeschool/opencode.school --visibility public
```