### PR TITLE
fix: make skills lesson flavor-agnostic across OpenCode variants

### DIFF
--- a/src/content/lessons/08-skills.mdx
+++ b/src/content/lessons/08-skills.mdx
@@ -4,7 +4,7 @@ slug: skills
 description: "Install reusable agent behaviors with Skills."
 order: 8
 quiz: true
-agentInstructions: "Cover these four topics: (1) what skills are — reusable instruction sets in SKILL.md files, originally created by Anthropic, now an open standard at agentskills.io, supported by 40+ AI tools including Claude Code, Codex, and Cursor, (2) how agents use skills — two ways: automatically when a task matches a skill's description, or manually when the user explicitly invokes a skill by name, (3) what a skill can contain — at minimum a SKILL.md file with name and description frontmatter plus instructions; can also bundle scripts, reference docs, templates, and other assets in the same folder, (4) why npx skills is the recommended install method — it installs to all your AI tools at once from a single command, rather than manually copying files for each tool. After teaching and quizzing, verify completion by checking that at least one skill directory exists under ~/.config/opencode/skills/ or ~/.agents/skills/ and contains a SKILL.md file. After marking the lesson complete, do NOT suggest moving on to the next lesson. Instead, tell the student: skills are loaded at startup, so they need to quit OpenCode Desktop and reopen it for the newly installed skills to take effect — and they can move on to the next lesson after restarting."
+agentInstructions: "Cover these four topics: (1) what skills are — reusable instruction sets in SKILL.md files, originally created by Anthropic, now an open standard at agentskills.io, supported by 40+ AI tools including Claude Code, Codex, and Cursor, (2) how agents use skills — two ways: automatically when a task matches a skill's description, or manually when the user explicitly invokes a skill by name, (3) what a skill can contain — at minimum a SKILL.md file with name and description frontmatter plus instructions; can also bundle scripts, reference docs, templates, and other assets in the same folder, (4) why npx skills is the recommended install method — it installs to all your AI tools at once from a single command, rather than manually copying files for each tool. After teaching and quizzing, verify completion by checking that at least one skill directory exists under ~/.config/opencode/skills/ or ~/.agents/skills/ and contains a SKILL.md file. After marking the lesson complete, do NOT suggest moving on to the next lesson. Instead, tell the student: skills are loaded at startup, so they need to quit OpenCode and reopen it for the newly installed skills to take effect. They can verify skills loaded by prompting 'list installed skills'. They can move on to the next lesson after restarting."
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'
@@ -66,7 +66,7 @@ Run each command in your terminal. The CLI will detect which AI tools you have i
 
 ## Restart OpenCode
 
-Skills are loaded when OpenCode starts. **Quit and reopen OpenCode Desktop** to pick up the newly installed skills, then use the prompt below to continue.
+Skills are loaded when OpenCode starts. **Quit and reopen OpenCode** to pick up the newly installed skills. You can verify they loaded by prompting "list installed skills". Then use the prompt below to continue.
 
 <AgentPrompt title="Skills" prompt={`I've installed skills and restarted OpenCode. Let's verify the Skills lesson is complete.`} />
 


### PR DESCRIPTION
This PR removes "OpenCode Desktop" references from the skills lesson so the restart instructions apply equally to the TUI, Desktop, and IDE extension.

- Changes "Quit and reopen OpenCode Desktop" to "Quit and reopen OpenCode"
- Adds a tip to verify skills loaded by prompting "list installed skills" instead of the `/skills` command which only exists in the TUI, but not in Desktop.
- Updates `agentInstructions` with the same changes