### PR TITLE
feat: add skill-creator to the skills lesson

### DIFF
--- a/src/content/lessons/08-skills.mdx
+++ b/src/content/lessons/08-skills.mdx
@@ -86,7 +86,7 @@ Or if it's something specific to one project:
 
 > That worked! I don't want to have to repeat myself, so let's create a project skill for this task.
 
-Global skills live in `~/.config/opencode/skills/` and apply to every project. Project skills live in `.opencode/skills/` within a repo and only apply there.
+Global skills live in `~/.config/opencode/skills/` and apply to every project. Project skills live in `.opencode/skills/` within a project directory and only apply within that project.
 
 ## Find more skills
 


### PR DESCRIPTION
This PR adds the [skill-creator](https://skills.sh/anthropics/skills/skill-creator) skill to the skills lesson and introduces a "Create your own skills" section.

- Adds `skill-creator` as the fourth skill to install (alongside Cloudflare, Replicate, and frontend-design)
- Adds a new section showing students how to turn any workflow into a reusable skill, with example prompts for creating global and project-level skills
- Updates "Install three skill collections" heading to "Install four skills"

Closes #80