### PR TITLE
feat: add Umami web analytics

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -537,6 +537,7 @@ const currentPath = Astro.url.pathname;
         },
       };
     </script>
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="a3d79131-e6af-4376-b614-b7bd60af46f8"></script>
   </head>
   <body class="min-h-screen">
     <div class="lg:flex">


### PR DESCRIPTION
This PR adds Umami Cloud analytics to the site by including the tracking script in the `<head>` of `Base.astro`.

Umami is privacy-focused, cookie-free, and GDPR-compliant. The script is ~2KB and deferred so it doesn't block page load. Dashboard at https://cloud.umami.is.