### PR TITLE
feat: add undo/reset progress API and redesign disenroll page

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -670,7 +670,7 @@ const currentPath = Astro.url.pathname;
           </a>
           <a
             id="sidebar-disenroll-link"
-            href="/troubleshooting#disenroll"
+            href="/disenroll"
             class="hidden block px-3 py-1.5 rounded-md text-sm transition-colors text-gray-600 hover:text-gray-900 hover:bg-gray-50 dark:text-stone-400 dark:hover:text-stone-200 dark:hover:bg-stone-800"
           >
             Disenroll

--- a/src/lib/progress.test.ts
+++ b/src/lib/progress.test.ts
@@ -3,7 +3,15 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createStudent, getProgress, markLessonComplete } from "./progress";
+import {
+	createStudent,
+	getProgress,
+	markExerciseComplete,
+	markExerciseIncomplete,
+	markLessonComplete,
+	markLessonIncomplete,
+	resetProgress,
+} from "./progress";
 
 /** Simple in-memory KV mock. */
 function createMockKv(): KVNamespace {
@@ -174,5 +182,141 @@ describe("markLessonComplete", () => {
 			"enrollment",
 			"install-opencode",
 		]);
+	});
+});
+
+describe("markLessonIncomplete", () => {
+	let kv: KVNamespace;
+
+	beforeEach(() => {
+		kv = createMockKv();
+	});
+
+	it("returns null for a non-existent student", async () => {
+		const result = await markLessonIncomplete(
+			kv,
+			"nobody-here-0000",
+			"enrollment",
+		);
+		expect(result).toBeNull();
+	});
+
+	it("removes a completed lesson", async () => {
+		await createStudent(kv, "eager-learner-1111");
+		await markLessonComplete(kv, "eager-learner-1111", "enrollment");
+		await markLessonComplete(kv, "eager-learner-1111", "installation");
+
+		const result = await markLessonIncomplete(
+			kv,
+			"eager-learner-1111",
+			"enrollment",
+		);
+
+		expect(result?.completedLessons).toHaveLength(1);
+		expect(result?.completedLessons[0].slug).toBe("installation");
+	});
+
+	it("is a no-op for a lesson that was not completed", async () => {
+		await createStudent(kv, "calm-coder-2222");
+		await markLessonComplete(kv, "calm-coder-2222", "enrollment");
+
+		const result = await markLessonIncomplete(
+			kv,
+			"calm-coder-2222",
+			"installation",
+		);
+
+		expect(result?.completedLessons).toHaveLength(1);
+		expect(result?.completedLessons[0].slug).toBe("enrollment");
+	});
+});
+
+describe("markExerciseIncomplete", () => {
+	let kv: KVNamespace;
+
+	beforeEach(() => {
+		kv = createMockKv();
+	});
+
+	it("returns null for a non-existent student", async () => {
+		const result = await markExerciseIncomplete(
+			kv,
+			"nobody-here-0000",
+			"build-a-website",
+		);
+		expect(result).toBeNull();
+	});
+
+	it("removes a completed exercise", async () => {
+		await createStudent(kv, "brave-builder-3333");
+		await markExerciseComplete(kv, "brave-builder-3333", "build-a-website");
+		await markExerciseComplete(kv, "brave-builder-3333", "edit-videos");
+
+		const result = await markExerciseIncomplete(
+			kv,
+			"brave-builder-3333",
+			"build-a-website",
+		);
+
+		expect(result?.completedExercises).toHaveLength(1);
+		expect(result?.completedExercises[0].slug).toBe("edit-videos");
+	});
+
+	it("is a no-op for an exercise that was not completed", async () => {
+		await createStudent(kv, "quick-thinker-4444");
+
+		const result = await markExerciseIncomplete(
+			kv,
+			"quick-thinker-4444",
+			"build-a-website",
+		);
+
+		expect(result?.completedExercises).toHaveLength(0);
+	});
+});
+
+describe("resetProgress", () => {
+	let kv: KVNamespace;
+
+	beforeEach(() => {
+		kv = createMockKv();
+	});
+
+	it("returns null for a non-existent student", async () => {
+		const result = await resetProgress(kv, "nobody-here-0000");
+		expect(result).toBeNull();
+	});
+
+	it("clears all lessons and exercises", async () => {
+		await createStudent(kv, "fresh-start-5555");
+		await markLessonComplete(kv, "fresh-start-5555", "enrollment");
+		await markLessonComplete(kv, "fresh-start-5555", "installation");
+		await markExerciseComplete(kv, "fresh-start-5555", "build-a-website");
+
+		const result = await resetProgress(kv, "fresh-start-5555");
+
+		expect(result?.completedLessons).toEqual([]);
+		expect(result?.completedExercises).toEqual([]);
+	});
+
+	it("preserves profile, createdAt, and deviceId", async () => {
+		const deviceId = "550e8400-e29b-41d4-a716-446655440000";
+		await createStudent(kv, "keeper-of-data-6666", deviceId);
+		await markLessonComplete(kv, "keeper-of-data-6666", "enrollment");
+
+		// Manually set a profile on the record
+		const progress = await getProgress(kv, "keeper-of-data-6666");
+		const stored = {
+			...progress,
+			profile: { codingExperience: "builder" as const },
+		};
+		await kv.put("student:keeper-of-data-6666", JSON.stringify(stored));
+
+		const result = await resetProgress(kv, "keeper-of-data-6666");
+
+		expect(result?.completedLessons).toEqual([]);
+		expect(result?.profile?.codingExperience).toBe("builder");
+		expect(result?.createdAt).toBe(progress?.createdAt);
+		expect(result?.deviceId).toBe(deviceId);
 	});
 });

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -162,6 +162,67 @@ export async function markExerciseComplete(
 	return progress;
 }
 
+/**
+ * Mark a lesson as incomplete for a student. Removes the lesson from the
+ * completedLessons array. No-op if the lesson wasn't completed. Returns the
+ * updated progress, or null if the student doesn't exist.
+ */
+export async function markLessonIncomplete(
+	kv: KVNamespace,
+	studentId: string,
+	lessonSlug: string,
+): Promise<StudentProgress | null> {
+	const progress = await getProgress(kv, studentId);
+	if (!progress) return null;
+
+	progress.completedLessons = progress.completedLessons.filter(
+		(l) => l.slug !== lessonSlug,
+	);
+	progress.updatedAt = new Date().toISOString();
+	await kv.put(kvKey(studentId), JSON.stringify(progress));
+	return progress;
+}
+
+/**
+ * Mark an exercise as incomplete for a student. Removes the exercise from the
+ * completedExercises array. No-op if the exercise wasn't completed. Returns the
+ * updated progress, or null if the student doesn't exist.
+ */
+export async function markExerciseIncomplete(
+	kv: KVNamespace,
+	studentId: string,
+	exerciseSlug: string,
+): Promise<StudentProgress | null> {
+	const progress = await getProgress(kv, studentId);
+	if (!progress) return null;
+
+	progress.completedExercises = progress.completedExercises.filter(
+		(e) => e.slug !== exerciseSlug,
+	);
+	progress.updatedAt = new Date().toISOString();
+	await kv.put(kvKey(studentId), JSON.stringify(progress));
+	return progress;
+}
+
+/**
+ * Reset all progress for a student. Clears completedLessons and
+ * completedExercises but preserves profile, createdAt, and deviceId.
+ * Returns the updated progress, or null if the student doesn't exist.
+ */
+export async function resetProgress(
+	kv: KVNamespace,
+	studentId: string,
+): Promise<StudentProgress | null> {
+	const progress = await getProgress(kv, studentId);
+	if (!progress) return null;
+
+	progress.completedLessons = [];
+	progress.completedExercises = [];
+	progress.updatedAt = new Date().toISOString();
+	await kv.put(kvKey(studentId), JSON.stringify(progress));
+	return progress;
+}
+
 /** Fetch a student's profile from KV. Returns null if the student doesn't exist. */
 export async function getProfile(
 	kv: KVNamespace,

--- a/src/pages/api/openapi.json.ts
+++ b/src/pages/api/openapi.json.ts
@@ -289,6 +289,76 @@ export const GET: APIRoute = (context) => {
 						},
 					},
 				},
+				delete: {
+					summary: "Undo a completion or reset all progress",
+					description:
+						'Removes a lesson or exercise from the student\'s completed list, or resets all progress. Send { "lessonSlug": "..." } to uncomplete a lesson, { "exerciseSlug": "..." } to uncomplete an exercise, or { "reset": true } to clear all completions. Resetting preserves the student\'s profile, enrollment date, and device ID.',
+					parameters: [
+						{
+							name: "studentId",
+							in: "path",
+							required: true,
+							schema: { type: "string" },
+							example: "analytical-pilgrim-5076",
+						},
+					],
+					requestBody: {
+						required: true,
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										lessonSlug: {
+											type: "string",
+											description:
+												"Slug of the lesson to mark incomplete. Provide this, exerciseSlug, or reset.",
+											example: "configuration",
+										},
+										exerciseSlug: {
+											type: "string",
+											description:
+												"Slug of the exercise to mark incomplete. Provide this, lessonSlug, or reset.",
+											example: "build-a-website",
+										},
+										reset: {
+											type: "boolean",
+											description:
+												"Set to true to clear all completed lessons and exercises. Preserves profile and enrollment metadata.",
+											example: true,
+										},
+									},
+								},
+							},
+						},
+					},
+					responses: {
+						"200": {
+							description: "Progress updated",
+							content: {
+								"application/json": {
+									schema: { $ref: "#/components/schemas/Progress" },
+								},
+							},
+						},
+						"400": {
+							description: "Invalid request",
+							content: {
+								"application/json": {
+									schema: { $ref: "#/components/schemas/Error" },
+								},
+							},
+						},
+						"404": {
+							description: "Student not found",
+							content: {
+								"application/json": {
+									schema: { $ref: "#/components/schemas/Error" },
+								},
+							},
+						},
+					},
+				},
 			},
 			"/api/profile/{studentId}": {
 				get: {

--- a/src/pages/api/progress/[studentId].ts
+++ b/src/pages/api/progress/[studentId].ts
@@ -8,13 +8,16 @@ import {
 	type CompletionSource,
 	getProgress,
 	markExerciseComplete,
+	markExerciseIncomplete,
 	markLessonComplete,
+	markLessonIncomplete,
+	resetProgress,
 } from "../../../lib/progress";
 import { isValidStudentId } from "../../../lib/student-id";
 
 const corsHeaders = {
 	"Access-Control-Allow-Origin": "*",
-	"Access-Control-Allow-Methods": "GET, PUT, OPTIONS",
+	"Access-Control-Allow-Methods": "GET, PUT, DELETE, OPTIONS",
 	"Access-Control-Allow-Headers": "Content-Type",
 };
 
@@ -96,6 +99,59 @@ export const PUT: APIRoute = async ({ params, request }) => {
 	const progress = hasExercise
 		? await markExerciseComplete(env.PROGRESS, studentId, slug, source, model)
 		: await markLessonComplete(env.PROGRESS, studentId, slug, source, model);
+	if (!progress) {
+		return notFound("Student not found");
+	}
+
+	return new Response(JSON.stringify(progress), {
+		headers: { "Content-Type": "application/json", ...corsHeaders },
+	});
+};
+
+export const DELETE: APIRoute = async ({ params, request }) => {
+	const { studentId } = params;
+	if (!studentId || !isValidStudentId(studentId)) {
+		return badRequest("Invalid student ID format");
+	}
+
+	let body: {
+		lessonSlug?: string;
+		exerciseSlug?: string;
+		reset?: boolean;
+	};
+	try {
+		body = await request.json();
+	} catch {
+		return badRequest("Invalid JSON body");
+	}
+
+	const isReset = body.reset === true;
+	const hasLesson =
+		typeof body.lessonSlug === "string" && body.lessonSlug.length > 0;
+	const hasExercise =
+		typeof body.exerciseSlug === "string" && body.exerciseSlug.length > 0;
+
+	if (!isReset && !hasLesson && !hasExercise) {
+		return badRequest('Provide "lessonSlug", "exerciseSlug", or "reset": true');
+	}
+
+	let progress: Awaited<ReturnType<typeof resetProgress>>;
+	if (isReset) {
+		progress = await resetProgress(env.PROGRESS, studentId);
+	} else if (hasExercise) {
+		progress = await markExerciseIncomplete(
+			env.PROGRESS,
+			studentId,
+			body.exerciseSlug as string,
+		);
+	} else {
+		progress = await markLessonIncomplete(
+			env.PROGRESS,
+			studentId,
+			body.lessonSlug as string,
+		);
+	}
+
 	if (!progress) {
 		return notFound("Student not found");
 	}

--- a/src/pages/disenroll.astro
+++ b/src/pages/disenroll.astro
@@ -7,7 +7,7 @@ export const prerender = true;
 import Base from "../layouts/Base.astro";
 ---
 
-<Base title="Disenroll" description="Clear your OpenCode School enrollment from this browser.">
+<Base title="Disenroll" description="Reset your progress or disenroll from OpenCode School.">
   <div class="mb-6">
     <a href="/" class="text-sm text-gray-500 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors">
       &larr; All lessons
@@ -16,37 +16,104 @@ import Base from "../layouts/Base.astro";
 
   <header class="mb-8">
     <h1 class="text-3xl font-bold">Disenroll</h1>
-    <p class="text-gray-600 dark:text-stone-400 mt-2">This will clear your student ID, progress, and theme color from this browser. Your data on the server is not affected.</p>
   </header>
 
-  <div id="disenroll-confirm">
-    <button
-      id="disenroll-button"
-      class="px-4 py-2 rounded-md text-sm font-medium bg-red-600 text-white hover:bg-red-700 transition-colors"
-    >
-      Disenroll from OpenCode School
-    </button>
+  <div id="no-enrollment" class="hidden">
+    <p class="text-gray-600 dark:text-stone-400">You are not currently enrolled. <a href="/" class="underline">Go to the homepage</a> to enroll.</p>
   </div>
 
-  <div id="disenroll-done" class="hidden">
-    <p class="text-gray-600 dark:text-stone-400">You have been disenrolled. Redirecting to the home page&hellip;</p>
-    <p class="text-gray-600 dark:text-stone-400 mt-4">If you added your OpenCode School instructions URL to your global OpenCode config, you should also remove the <code class="text-sm bg-gray-100 dark:bg-stone-800 px-1 py-0.5 rounded">instructions</code> entry from <code class="text-sm bg-gray-100 dark:bg-stone-800 px-1 py-0.5 rounded">~/.config/opencode/opencode.jsonc</code>.</p>
+  <div id="enrolled-options" class="hidden">
+    <!-- Reset progress (primary action) -->
+    <div class="mb-8 p-6 border border-gray-200 dark:border-stone-700 rounded-lg">
+      <h2 class="text-xl font-semibold mb-2">Reset progress</h2>
+      <p class="text-gray-600 dark:text-stone-400 mb-4">Clear all your lesson and exercise completions so you can redo them. Your student ID and profile are kept.</p>
+      <div id="reset-confirm">
+        <button
+          id="reset-button"
+          class="px-4 py-2 rounded-md text-sm font-medium bg-orange-600 text-white hover:bg-orange-700 transition-colors"
+        >
+          Reset my progress
+        </button>
+      </div>
+      <div id="reset-done" class="hidden">
+        <p class="text-gray-600 dark:text-stone-400">Progress has been reset. Your student ID is unchanged. <a href="/" class="underline">Go to the homepage</a> to start over.</p>
+      </div>
+      <div id="reset-error" class="hidden">
+        <p class="text-red-600 dark:text-red-400">Something went wrong resetting your progress. Try again or disenroll instead.</p>
+      </div>
+    </div>
+
+    <!-- Disenroll (secondary/destructive action) -->
+    <div class="p-6 border border-gray-200 dark:border-stone-700 rounded-lg">
+      <h2 class="text-xl font-semibold mb-2">Disenroll completely</h2>
+      <p class="text-gray-600 dark:text-stone-400 mb-4">Remove your student ID, progress, and theme color from this browser. Your data on the server is not affected. You will need to re-enroll to use OpenCode School again.</p>
+      <div id="disenroll-confirm">
+        <button
+          id="disenroll-button"
+          class="px-4 py-2 rounded-md text-sm font-medium border border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950 transition-colors"
+        >
+          Disenroll from OpenCode School
+        </button>
+      </div>
+      <div id="disenroll-done" class="hidden">
+        <p class="text-gray-600 dark:text-stone-400">You have been disenrolled. Redirecting to the home page&hellip;</p>
+        <p class="text-gray-600 dark:text-stone-400 mt-4">If you added your OpenCode School instructions URL to your global OpenCode config, you should also remove the <code class="text-sm bg-gray-100 dark:bg-stone-800 px-1 py-0.5 rounded">instructions</code> entry from <code class="text-sm bg-gray-100 dark:bg-stone-800 px-1 py-0.5 rounded">~/.config/opencode/opencode.jsonc</code>.</p>
+      </div>
+    </div>
   </div>
 
   <script is:inline>
-    document.getElementById("disenroll-button").addEventListener("click", function () {
-      localStorage.removeItem("studentId");
-      localStorage.removeItem("themeColor");
-      localStorage.removeItem("progress");
-      document.getElementById("disenroll-confirm").classList.add("hidden");
-      document.getElementById("disenroll-done").classList.remove("hidden");
-      setTimeout(function () {
-        window.location.replace("/");
-      }, 1500);
-    });
+    (function () {
+      var studentId = localStorage.getItem("studentId");
+      if (!studentId) {
+        document.getElementById("no-enrollment").classList.remove("hidden");
+        return;
+      }
+
+      document.getElementById("enrolled-options").classList.remove("hidden");
+
+      // Reset progress
+      document.getElementById("reset-button").addEventListener("click", function () {
+        var btn = this;
+        btn.disabled = true;
+        btn.textContent = "Resetting\u2026";
+
+        fetch("/api/progress/" + encodeURIComponent(studentId), {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reset: true }),
+        })
+          .then(function (res) {
+            if (!res.ok) throw new Error("Reset failed");
+            return res.json();
+          })
+          .then(function (progress) {
+            localStorage.setItem("progress", JSON.stringify(progress));
+            document.getElementById("reset-confirm").classList.add("hidden");
+            document.getElementById("reset-done").classList.remove("hidden");
+          })
+          .catch(function () {
+            btn.disabled = false;
+            btn.textContent = "Reset my progress";
+            document.getElementById("reset-error").classList.remove("hidden");
+          });
+      });
+
+      // Disenroll
+      document.getElementById("disenroll-button").addEventListener("click", function () {
+        localStorage.removeItem("studentId");
+        localStorage.removeItem("themeColor");
+        localStorage.removeItem("progress");
+        document.getElementById("disenroll-confirm").classList.add("hidden");
+        document.getElementById("disenroll-done").classList.remove("hidden");
+        setTimeout(function () {
+          window.location.replace("/");
+        }, 1500);
+      });
+    })();
   </script>
 
   <noscript>
-    <p>JavaScript is required to disenroll. Please enable it and try again.</p>
+    <p>JavaScript is required to use this page. Please enable it and try again.</p>
   </noscript>
 </Base>

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -20,6 +20,12 @@ Each lesson and exercise has \`agentInstructions\` describing what is required a
 
 When the criteria are met, mark the lesson or exercise complete via API before telling the student, then summarize what was accomplished, and ask if they want to proceed to the next one. When marking a lesson complete, send \`{ "lessonSlug": "..." }\`. When marking an exercise complete, send \`{ "exerciseSlug": "..." }\`. Always include the \`model\` field in the request body with the model ID you are currently running as (e.g. \`anthropic/claude-sonnet-4-5\`).
 
+## Redoing completed lessons or exercises
+
+If a student wants to redo a lesson or exercise they've already completed, use DELETE /api/progress/{studentId} with \`{ "lessonSlug": "..." }\` or \`{ "exerciseSlug": "..." }\` to mark it incomplete first, then proceed with the lesson normally as if they hadn't done it before. Don't skip it just because it was previously completed — the student is explicitly asking to go through it again.
+
+To reset all progress while keeping the student's ID and profile, send DELETE /api/progress/{studentId} with \`{ "reset": true }\`. This clears all completed lessons and exercises but preserves their profile, enrollment date, and device ID.
+
 Exercises are available at GET /api/exercises (list all) and GET /api/exercises/{slug} (single exercise).
 
 ## Exercise prerequisites

--- a/src/pages/troubleshooting.astro
+++ b/src/pages/troubleshooting.astro
@@ -90,16 +90,23 @@ import Base from "../layouts/Base.astro";
       The more detail you provide, the easier it is to fix.
     </p>
 
-    <h2 id="disenroll"><a href="#disenroll" class="heading-anchor">How to disenroll</a></h2>
+    <h2 id="disenroll"><a href="#disenroll" class="heading-anchor">How to reset progress or disenroll</a></h2>
     <p>
-      If you want to start fresh or clear your enrollment from this browser,
-      visit the <a href="/disenroll">disenroll page</a>. This removes your
-      student ID, progress, and theme color from your browser's local storage.
+      If you want to redo lessons you've already completed, visit the
+      <a href="/disenroll">disenroll page</a> and use "Reset progress." This
+      clears all your completions while keeping your student ID and profile, so
+      you can go through the lessons again without re-enrolling.
     </p>
     <p>
-      Note that disenrolling only clears data in your current browser. There is
-      no account to delete on the server side — your progress record is just a
-      small anonymous entry keyed to your student ID.
+      If you want to fully clear your enrollment from this browser, the same page
+      has a "Disenroll completely" option that removes your student ID, progress,
+      and theme color from local storage. You would need to re-enroll to use
+      OpenCode School again.
+    </p>
+    <p>
+      Note that both options only affect your current browser. There is no
+      account to delete on the server side — your progress record is just a small
+      anonymous entry keyed to your student ID.
     </p>
   </article>
 </Base>


### PR DESCRIPTION
This PR adds the ability to undo lesson/exercise completions and reset all progress without disenrolling.

## Problem

Students skip ahead in the browser, which marks lessons as complete. The agent then sees "already completed" and refuses to reteach the lesson. The only workaround is disenrolling (losing the student ID) and re-enrolling from scratch.

## What changed

- `DELETE /api/progress/{studentId}` accepts `{ "lessonSlug": "..." }` to uncomplete a single lesson, `{ "exerciseSlug": "..." }` for an exercise, or `{ "reset": true }` to clear all completions while preserving the student's ID, profile, and enrollment metadata
- `/disenroll` page redesigned with two options: "Reset progress" (primary, keeps student ID) and "Disenroll completely" (secondary, clears localStorage)
- Agent instructions in `llms.txt` updated so agents know to use DELETE before reteaching a completed lesson
- Sidebar "Disenroll" link now points to `/disenroll` instead of `/troubleshooting#disenroll`
- Troubleshooting page updated to describe both reset and disenroll options
- 8 new tests for `markLessonIncomplete`, `markExerciseIncomplete`, and `resetProgress`