### PR TITLE
feat: add changelog with RSS feed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@astrojs/cloudflare": "^13.1.1",
         "@astrojs/mdx": "^5.0.0",
+        "@astrojs/rss": "^4.0.18",
         "@fontsource/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@resvg/resvg-js": "^2.6.2",
@@ -128,6 +129,17 @@
       },
       "engines": {
         "node": "^20.19.1 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -3740,6 +3752,41 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.11.tgz",
+      "integrity": "sha512-QL0eb0YbSTVWF6tTf1+LEMSgtCEjBYPpnAjoLC8SscESlAjXEIRJ7cHtLG0pLeDFaZLa4VKZLArtA/60ZS7vyA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.4.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5909,6 +5956,21 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -6625,6 +6687,18 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@astrojs/cloudflare": "^13.1.1",
     "@astrojs/mdx": "^5.0.0",
+    "@astrojs/rss": "^4.0.18",
     "@fontsource/inter": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@resvg/resvg-js": "^2.6.2",

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -9,9 +9,10 @@ interface Props {
   title?: string;
   description?: string;
   ogImage?: string;
+  rssHref?: string;
 }
 
-const { title, description = "Learn to use OpenCode, the free and open-source AI coding agent.", ogImage } = Astro.props;
+const { title, description = "Learn to use OpenCode, the free and open-source AI coding agent.", ogImage, rssHref } = Astro.props;
 const pageTitle = title ? `${title} | OpenCode School` : "OpenCode School";
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
 const ogImageUrl = new URL(ogImage || "/og/default.png", Astro.site).href;
@@ -41,6 +42,7 @@ const currentPath = Astro.url.pathname;
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImageUrl} />
     <title>{pageTitle}</title>
+    {rssHref && <link rel="alternate" type="application/rss+xml" title="OpenCode School Changelog" href={rssHref} />}
     <script is:inline>
       window.__schoolThemePalettes = {
         blue: {
@@ -645,6 +647,17 @@ const currentPath = Astro.url.pathname;
             ]}
           >
             Tips
+          </a>
+          <a
+            href="/changelog"
+            class:list={[
+              "block px-3 py-1.5 rounded-md text-sm transition-colors",
+              currentPath === "/changelog" || currentPath === "/changelog/"
+                ? "theme-active-nav font-medium"
+                : "text-gray-600 hover:text-gray-900 hover:bg-gray-50 dark:text-stone-400 dark:hover:text-stone-200 dark:hover:bg-stone-800",
+            ]}
+          >
+            Changelog
           </a>
           <a
             href="/glossary"

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+export interface ChangelogEntry {
+	slug: string;
+	date: string; // YYYY-MM-DD
+	title: string;
+	description: string;
+}
+
+export const changelogEntries: ChangelogEntry[] = [
+	{
+		slug: "open-source",
+		date: "2026-04-07",
+		title: "OpenCode School is now open source",
+		description:
+			"The [source code](https://github.com/opencodeschool/opencode.school) is available on GitHub under the Apache 2.0 license. Contributions are welcome.",
+	},
+	{
+		slug: "tips-page",
+		date: "2026-04-05",
+		title: "New page: Tips and tricks",
+		description:
+			"Practical guidance for getting the most out of OpenCode, collected on a single [Tips](/tips) page.",
+	},
+	{
+		slug: "tools-and-permissions-content",
+		date: "2026-04-05",
+		title: "New content in Tools and Permissions",
+		description:
+			"The [Tools](/lessons/tools) lesson now covers the /mcp command and config editing. The [Permissions](/lessons/permissions) lesson covers external_directory. Both lessons note that Plan mode is not a guaranteed sandbox.",
+	},
+	{
+		slug: "exercises",
+		date: "2026-04-03",
+		title: "Introducing exercises",
+		description:
+			"Five hands-on [exercises](/exercises) that go beyond the lesson material: build a website, drive a browser, edit videos, run AI models, and transcribe speech.",
+	},
+	{
+		slug: "about-page",
+		date: "2026-04-01",
+		title: "New page: About",
+		description:
+			"An [About](/about) page with project info, logos, and links to the community.",
+	},
+	{
+		slug: "desktop-ui-tour",
+		date: "2026-04-01",
+		title: "Video tour of the desktop UI",
+		description:
+			"The [Installation](/lessons/installation) lesson now includes a video walkthrough of the OpenCode desktop interface.",
+	},
+	{
+		slug: "context-windows",
+		date: "2026-04-01",
+		title: "Explaining context windows",
+		description:
+			"The [Models](/lessons/models) lesson now covers context windows and how they affect model behavior.",
+	},
+	{
+		slug: "auto-navigate",
+		date: "2026-03-31",
+		title: "Automatic navigation between lessons",
+		description:
+			"The browser now moves to the next lesson when an agent marks the current one complete. No more manual clicking between lessons.",
+	},
+	{
+		slug: "interview-lesson",
+		date: "2026-03-31",
+		title: "New: Interviews for new students",
+		description:
+			"An [interview lesson](/lessons/interview) that asks about your background and preferences to personalize the rest of the course.",
+	},
+	{
+		slug: "quiz-ux",
+		date: "2026-03-31",
+		title: "All quiz questions shown at once",
+		description:
+			"Quizzes now present every question on a single screen instead of walking through them one at a time.",
+	},
+];

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -11,11 +11,74 @@ export interface ChangelogEntry {
 
 export const changelogEntries: ChangelogEntry[] = [
 	{
+		slug: "progress-reset",
+		date: "2026-04-09",
+		title: "Reset your progress",
+		description:
+			"Students can now undo individual lesson completions or reset all progress from the [disenroll](/disenroll) page.",
+	},
+	{
+		slug: "more-exercises",
+		date: "2026-04-08",
+		title: "Two new exercises",
+		description:
+			"[Use Git and GitHub](/exercises/use-git-and-github) and [Post to social media](/exercises/post-to-social-media) join the exercises lineup.",
+	},
+	{
+		slug: "ai-gateway",
+		date: "2026-04-08",
+		title: "Cloudflare AI Gateway in the models lesson",
+		description:
+			"The [Models](/lessons/models) lesson now covers Cloudflare AI Gateway and Workers AI as provider options.",
+	},
+	{
+		slug: "anchor-links",
+		date: "2026-04-08",
+		title: "Shareable heading links",
+		description:
+			"Prose headings throughout the site now have anchor links, making it easy to link to a specific section.",
+	},
+	{
+		slug: "plugins-lesson",
+		date: "2026-04-07",
+		title: "New lesson: Plugins",
+		description:
+			"A new [Plugins](/lessons/plugins) lesson on extending OpenCode with community and custom plugins.",
+	},
+	{
+		slug: "og-images",
+		date: "2026-04-07",
+		title: "OpenGraph images",
+		description:
+			"Every lesson and exercise page now has a unique OpenGraph image for better previews when shared on social media.",
+	},
+	{
+		slug: "skill-creator",
+		date: "2026-04-07",
+		title: "Skill creator in the skills lesson",
+		description:
+			"The [Skills](/lessons/skills) lesson now walks through building your own skill from scratch.",
+	},
+	{
+		slug: "not-just-coding",
+		date: "2026-04-07",
+		title: "OpenCode is not just for coding",
+		description:
+			"Lesson content and site copy now reflect that OpenCode is a general-purpose AI agent, not exclusively a coding tool.",
+	},
+	{
 		slug: "open-source",
 		date: "2026-04-07",
 		title: "OpenCode School is now open source",
 		description:
 			"The [source code](https://github.com/opencodeschool/opencode.school) is available on GitHub under the Apache 2.0 license. Contributions are welcome.",
+	},
+	{
+		slug: "plan-mode-default",
+		date: "2026-04-06",
+		title: "Plan mode as the default",
+		description:
+			"The [Configuration](/lessons/configuration) lesson now recommends starting in plan mode with defensive bash permissions, so new students can learn safely.",
 	},
 	{
 		slug: "tips-page",

--- a/src/pages/changelog.xml.ts
+++ b/src/pages/changelog.xml.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export const prerender = true;
+
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+import { changelogEntries } from "../lib/changelog";
+
+export function GET(context: APIContext) {
+	return rss({
+		title: "OpenCode School Changelog",
+		description: "What's new on OpenCode School.",
+		site: context.site?.toString() ?? "https://opencode.school",
+		items: changelogEntries.map((entry) => ({
+			title: entry.title,
+			description: entry.description,
+			pubDate: new Date(entry.date),
+			link: `/changelog/${entry.slug}`,
+		})),
+	});
+}

--- a/src/pages/changelog/[slug].astro
+++ b/src/pages/changelog/[slug].astro
@@ -1,0 +1,40 @@
+---
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export const prerender = true;
+
+import Base from "../../layouts/Base.astro";
+import { changelogEntries } from "../../lib/changelog";
+import { marked } from "marked";
+
+export function getStaticPaths() {
+  return changelogEntries.map((entry) => ({
+    params: { slug: entry.slug },
+    props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+  return date.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
+}
+---
+
+<Base title={entry.title} description={entry.description.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")}>
+  <div class="mb-6">
+    <a href="/changelog" class="text-sm text-gray-500 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors">
+      &larr; Changelog
+    </a>
+  </div>
+
+  <header class="mb-8">
+    <h1 class="text-3xl font-bold">{entry.title}</h1>
+    <time datetime={entry.date} class="text-sm text-gray-500 dark:text-stone-500 mt-2 block">{formatDate(entry.date)}</time>
+  </header>
+
+  <article class="prose dark:prose-invert max-w-none prose-a:font-normal" set:html={marked.parse(entry.description)} />
+</Base>

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -1,0 +1,52 @@
+---
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export const prerender = true;
+
+import Base from "../../layouts/Base.astro";
+import { changelogEntries } from "../../lib/changelog";
+import { marked } from "marked";
+
+const sorted = [...changelogEntries].sort((a, b) => b.date.localeCompare(a.date));
+
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+---
+
+<Base title="Changelog" description="What's new on OpenCode School." rssHref="/changelog.xml">
+  <div class="mb-6">
+    <a href="/" class="text-sm text-gray-500 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors">
+      &larr; All lessons
+    </a>
+  </div>
+
+  <header class="mb-10">
+    <div class="flex items-center justify-between">
+      <h1 class="text-3xl font-bold">Changelog</h1>
+      <a href="/changelog.xml" class="text-sm text-gray-500 dark:text-stone-500 hover:text-gray-700 dark:hover:text-stone-300 transition-colors" title="RSS Feed">
+        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19.01 7.38 20 6.18 20 4.97 20 4 19.01 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z"/>
+        </svg>
+      </a>
+    </div>
+    <p class="text-gray-600 dark:text-stone-400 mt-2 text-lg">What's new on OpenCode School.</p>
+  </header>
+
+  <ul class="space-y-6">
+    {sorted.map((entry) => (
+      <li>
+        <div class="flex items-baseline gap-4">
+          <time datetime={entry.date} class="text-sm text-gray-400 dark:text-stone-500 shrink-0 w-16 tabular-nums">{formatDate(entry.date)}</time>
+          <div>
+            <a href={`/changelog/${entry.slug}`} class="font-medium text-gray-900 dark:text-stone-200 hover:underline">{entry.title}</a>
+            <div class="text-sm text-gray-600 dark:text-stone-400 mt-1 prose-sm prose-a:text-gray-600 dark:prose-a:text-stone-400 prose-a:underline" set:html={marked.parseInline(entry.description)} />
+          </div>
+        </div>
+      </li>
+    ))}
+  </ul>
+</Base>


### PR DESCRIPTION
This PR adds a changelog to the site.

- `/changelog` — index page listing all entries with dates on the left, titles linking to individual entry pages, and descriptions with inline markdown links to relevant pages
- `/changelog/{slug}` — individual permalink pages for each entry
- `/changelog.xml` — RSS feed via `@astrojs/rss`
- Sidebar link between Tips and Glossary
- RSS autodiscovery `<link>` tag on the changelog page via a new `rssHref` prop on the Base layout
- `site` added to `astro.config.mjs` (required by `@astrojs/rss`)

Entries are defined in `src/lib/changelog.ts` as a curated array. To add new entries, append to the array with a `slug`, `date`, `title`, and `description` (supports inline markdown).