### PR TITLE
fix: validate lesson and exercise slugs in progress API

### DIFF
--- a/script/clean-progress
+++ b/script/clean-progress
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Valid lesson and exercise slugs (derived from src/content/lessons/ and src/content/exercises/).
+# Update these arrays if lessons or exercises are added or removed.
+VALID_LESSON_SLUGS=(
+  installation interview configuration permissions instructions
+  models commands skills tools plugins agents sessions images workspaces
+)
+VALID_EXERCISE_SLUGS=(
+  build-a-website run-ai-models edit-videos transcribe-speech
+  drive-a-browser post-to-social-media use-git-and-github
+)
+
+KV_NAMESPACE_ID="3bd04cd0e35548b181036e6385b5120c"
+DRY_RUN=true
+FIXED=0
+SCANNED=0
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Scan all student progress records in KV and remove any completedLessons
+or completedExercises entries with slugs that don't match the current
+content collection. Useful for cleaning up hallucinated or stale slugs.
+
+Options:
+  --apply   Actually write changes (default is dry-run)
+  -h, --help  Show this help message
+EOF
+  exit 0
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --apply) DRY_RUN=false ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $arg" >&2; exit 1 ;;
+  esac
+done
+
+is_valid_lesson() {
+  local slug="$1"
+  for valid in "${VALID_LESSON_SLUGS[@]}"; do
+    [[ "$valid" == "$slug" ]] && return 0
+  done
+  return 1
+}
+
+is_valid_exercise() {
+  local slug="$1"
+  for valid in "${VALID_EXERCISE_SLUGS[@]}"; do
+    [[ "$valid" == "$slug" ]] && return 0
+  done
+  return 1
+}
+
+if $DRY_RUN; then
+  echo "DRY RUN — no changes will be written. Pass --apply to write changes."
+  echo ""
+fi
+
+# List all keys in the KV namespace
+cursor=""
+all_keys=()
+
+while true; do
+  if [[ -z "$cursor" ]]; then
+    result=$(npx wrangler kv key list --namespace-id "$KV_NAMESPACE_ID" --remote 2>/dev/null)
+  else
+    result=$(npx wrangler kv key list --namespace-id "$KV_NAMESPACE_ID" --remote --cursor "$cursor" 2>/dev/null)
+  fi
+
+  # Extract key names
+  keys=$(echo "$result" | jq -r '.[].name // empty' 2>/dev/null || true)
+  if [[ -n "$keys" ]]; then
+    while IFS= read -r key; do
+      all_keys+=("$key")
+    done <<< "$keys"
+  fi
+
+  # Check for pagination cursor
+  cursor=$(echo "$result" | jq -r '.result_info.cursor // empty' 2>/dev/null || true)
+  if [[ -z "$cursor" ]]; then
+    break
+  fi
+done
+
+echo "Found ${#all_keys[@]} keys in KV namespace."
+echo ""
+
+for key in "${all_keys[@]}"; do
+  # Only process student: keys
+  [[ "$key" != student:* ]] && continue
+
+  SCANNED=$((SCANNED + 1))
+  student_id="${key#student:}"
+
+  # Fetch the record
+  record=$(npx wrangler kv key get "$key" --namespace-id "$KV_NAMESPACE_ID" --remote 2>/dev/null)
+
+  # Check for invalid lesson slugs
+  invalid_lessons=$(echo "$record" | jq -r '
+    [.completedLessons[]? |
+      if type == "string" then . else .slug end
+    ] | .[]' 2>/dev/null | while IFS= read -r slug; do
+    if ! is_valid_lesson "$slug"; then
+      echo "$slug"
+    fi
+  done)
+
+  # Check for invalid exercise slugs
+  invalid_exercises=$(echo "$record" | jq -r '
+    [.completedExercises[]? |
+      if type == "string" then . else .slug end
+    ] | .[]' 2>/dev/null | while IFS= read -r slug; do
+    if ! is_valid_exercise "$slug"; then
+      echo "$slug"
+    fi
+  done)
+
+  if [[ -n "$invalid_lessons" ]] || [[ -n "$invalid_exercises" ]]; then
+    echo "Student: $student_id"
+    if [[ -n "$invalid_lessons" ]]; then
+      echo "  Invalid lessons: $invalid_lessons"
+    fi
+    if [[ -n "$invalid_exercises" ]]; then
+      echo "  Invalid exercises: $invalid_exercises"
+    fi
+
+    if ! $DRY_RUN; then
+      # Build jq filter to remove invalid entries
+      updated=$(echo "$record" | jq \
+        --argjson valid_lessons "$(printf '%s\n' "${VALID_LESSON_SLUGS[@]}" | jq -R . | jq -s .)" \
+        --argjson valid_exercises "$(printf '%s\n' "${VALID_EXERCISE_SLUGS[@]}" | jq -R . | jq -s .)" \
+        '
+        .completedLessons = [.completedLessons[]? | select(
+          (if type == "string" then . else .slug end) as $s |
+          $valid_lessons | index($s) != null
+        )] |
+        .completedExercises = [.completedExercises[]? | select(
+          (if type == "string" then . else .slug end) as $s |
+          $valid_exercises | index($s) != null
+        )] |
+        .updatedAt = now | todate
+        ')
+
+      echo "$updated" | npx wrangler kv key put "$key" --namespace-id "$KV_NAMESPACE_ID" --remote 2>/dev/null
+      echo "  -> Fixed."
+    fi
+
+    FIXED=$((FIXED + 1))
+  fi
+done
+
+echo ""
+echo "Scanned $SCANNED student records."
+if $DRY_RUN; then
+  echo "Found $FIXED records with invalid slugs (dry run, no changes made)."
+  if [[ $FIXED -gt 0 ]]; then
+    echo "Run with --apply to fix them."
+  fi
+else
+  echo "Fixed $FIXED records."
+fi

--- a/src/lib/valid-slugs.test.ts
+++ b/src/lib/valid-slugs.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("astro:content", () => ({
+	getCollection: vi.fn(),
+}));
+
+import { validateSlug } from "./valid-slugs";
+
+const lessonSlugs = new Set([
+	"installation",
+	"interview",
+	"configuration",
+	"permissions",
+	"instructions",
+]);
+
+const exerciseSlugs = new Set([
+	"build-a-website",
+	"run-ai-models",
+	"edit-videos",
+]);
+
+describe("validateSlug", () => {
+	it("returns null for a valid lesson slug", () => {
+		expect(validateSlug("installation", lessonSlugs, "lesson")).toBeNull();
+	});
+
+	it("returns null for a valid exercise slug", () => {
+		expect(
+			validateSlug("build-a-website", exerciseSlugs, "exercise"),
+		).toBeNull();
+	});
+
+	it("returns an error for an unknown lesson slug", () => {
+		expect(validateSlug("nonexistent", lessonSlugs, "lesson")).toBe(
+			'Unknown lesson slug: "nonexistent"',
+		);
+	});
+
+	it("returns an error for an unknown exercise slug", () => {
+		expect(validateSlug("internal-data-mcp", exerciseSlugs, "exercise")).toBe(
+			'Unknown exercise slug: "internal-data-mcp"',
+		);
+	});
+
+	it("returns an error for an empty slug", () => {
+		expect(validateSlug("", lessonSlugs, "lesson")).toBe(
+			'Unknown lesson slug: ""',
+		);
+	});
+
+	it("is case-sensitive", () => {
+		expect(validateSlug("Installation", lessonSlugs, "lesson")).toBe(
+			'Unknown lesson slug: "Installation"',
+		);
+	});
+});

--- a/src/lib/valid-slugs.ts
+++ b/src/lib/valid-slugs.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { getCollection } from "astro:content";
+
+export async function getValidSlugs(): Promise<{
+	lessonSlugs: Set<string>;
+	exerciseSlugs: Set<string>;
+}> {
+	const [lessons, exercises] = await Promise.all([
+		getCollection("lessons"),
+		getCollection("exercises"),
+	]);
+	return {
+		lessonSlugs: new Set(lessons.map((l) => l.data.slug)),
+		exerciseSlugs: new Set(exercises.map((e) => e.data.slug)),
+	};
+}
+
+/**
+ * Validate that a slug exists in the given set. Returns an error message
+ * if invalid, or null if valid.
+ */
+export function validateSlug(
+	slug: string,
+	validSlugs: Set<string>,
+	type: "lesson" | "exercise",
+): string | null {
+	if (!validSlugs.has(slug)) {
+		return `Unknown ${type} slug: "${slug}"`;
+	}
+	return null;
+}

--- a/src/pages/api/openapi.json.ts
+++ b/src/pages/api/openapi.json.ts
@@ -215,7 +215,7 @@ export const GET: APIRoute = (context) => {
 				put: {
 					summary: "Mark a lesson or exercise as complete",
 					description:
-						"Marks a lesson or exercise as complete for the given student. Supply either lessonSlug or exerciseSlug (not both). Idempotent — marking an already-completed item has no effect.",
+						"Marks a lesson or exercise as complete for the given student. Supply either lessonSlug or exerciseSlug (not both). Idempotent — marking an already-completed item has no effect. The slug must match an existing lesson or exercise; unknown slugs are rejected with a 400 error.",
 					parameters: [
 						{
 							name: "studentId",
@@ -235,13 +235,13 @@ export const GET: APIRoute = (context) => {
 										lessonSlug: {
 											type: "string",
 											description:
-												"Slug of the lesson to mark complete. Provide this or exerciseSlug.",
+												"Slug of the lesson to mark complete. Must match an existing lesson. Provide this or exerciseSlug.",
 											example: "configuration",
 										},
 										exerciseSlug: {
 											type: "string",
 											description:
-												"Slug of the exercise to mark complete. Provide this or lessonSlug.",
+												"Slug of the exercise to mark complete. Must match an existing exercise. Provide this or lessonSlug.",
 											example: "build-a-website",
 										},
 										source: {
@@ -292,7 +292,7 @@ export const GET: APIRoute = (context) => {
 				delete: {
 					summary: "Undo a completion or reset all progress",
 					description:
-						'Removes a lesson or exercise from the student\'s completed list, or resets all progress. Send { "lessonSlug": "..." } to uncomplete a lesson, { "exerciseSlug": "..." } to uncomplete an exercise, or { "reset": true } to clear all completions. Resetting preserves the student\'s profile, enrollment date, and device ID.',
+						'Removes a lesson or exercise from the student\'s completed list, or resets all progress. Send { "lessonSlug": "..." } to uncomplete a lesson, { "exerciseSlug": "..." } to uncomplete an exercise, or { "reset": true } to clear all completions. Resetting preserves the student\'s profile, enrollment date, and device ID. The slug must match an existing lesson or exercise; unknown slugs are rejected with a 400 error.',
 					parameters: [
 						{
 							name: "studentId",

--- a/src/pages/api/progress/[studentId].ts
+++ b/src/pages/api/progress/[studentId].ts
@@ -14,6 +14,7 @@ import {
 	resetProgress,
 } from "../../../lib/progress";
 import { isValidStudentId } from "../../../lib/student-id";
+import { getValidSlugs, validateSlug } from "../../../lib/valid-slugs";
 
 const corsHeaders = {
 	"Access-Control-Allow-Origin": "*",
@@ -96,6 +97,14 @@ export const PUT: APIRoute = async ({ params, request }) => {
 		? (body.exerciseSlug as string)
 		: (body.lessonSlug as string);
 
+	const { lessonSlugs, exerciseSlugs } = await getValidSlugs();
+	const slugError = hasExercise
+		? validateSlug(slug, exerciseSlugs, "exercise")
+		: validateSlug(slug, lessonSlugs, "lesson");
+	if (slugError) {
+		return badRequest(slugError);
+	}
+
 	const progress = hasExercise
 		? await markExerciseComplete(env.PROGRESS, studentId, slug, source, model)
 		: await markLessonComplete(env.PROGRESS, studentId, slug, source, model);
@@ -133,6 +142,19 @@ export const DELETE: APIRoute = async ({ params, request }) => {
 
 	if (!isReset && !hasLesson && !hasExercise) {
 		return badRequest('Provide "lessonSlug", "exerciseSlug", or "reset": true');
+	}
+
+	if (!isReset) {
+		const { lessonSlugs, exerciseSlugs } = await getValidSlugs();
+		const slug = hasExercise
+			? (body.exerciseSlug as string)
+			: (body.lessonSlug as string);
+		const slugError = hasExercise
+			? validateSlug(slug, exerciseSlugs, "exercise")
+			: validateSlug(slug, lessonSlugs, "lesson");
+		if (slugError) {
+			return badRequest(slugError);
+		}
 	}
 
 	let progress: Awaited<ReturnType<typeof resetProgress>>;


### PR DESCRIPTION
This PR adds slug validation to the progress API so that only real lesson and exercise slugs are accepted.

The `PUT` and `DELETE` handlers for `/api/progress/{studentId}` now check submitted slugs against the Astro content collections at request time. Unknown slugs are rejected with a 400 error like `Unknown exercise slug: "internal-data-mcp"`.

Also includes:
- `script/clean-progress` for scrubbing invalid slugs from existing KV records (dry-run by default, `--apply` to write)
- Unit tests for the new `validateSlug` helper
- Updated OpenAPI spec descriptions to document the new validation

The hallucinated `internal-data-mcp` exercise completion from #120 has already been removed from the affected KV record.

Closes #120