### PR TITLE
fix: replace vague MCP discovery guidance with concrete links

### DIFF
--- a/src/content/lessons/09-tools.mdx
+++ b/src/content/lessons/09-tools.mdx
@@ -76,4 +76,6 @@ Each MCP server you add registers its tools with the model at the start of every
 
 ## Find more MCP servers
 
-The [OpenCode MCP docs](https://opencode.ai/docs/mcp-servers/) include ready-to-use examples for services like Sentry, Context7, and Grep. Beyond that, the broader MCP ecosystem has hundreds of servers for GitHub, Notion, Slack, databases, and more — a growing library of ways to give your AI agent new capabilities.
+The [OpenCode MCP docs](https://opencode.ai/docs/mcp-servers/) include ready-to-use config examples for Sentry, Context7, and Grep. For broader discovery, the [official MCP registry](https://registry.modelcontextprotocol.io) indexes thousands of servers across categories like databases, developer tools, and productivity — backed by Anthropic, GitHub, and Microsoft.
+
+You can also ask OpenCode to find and install MCP servers for you — describe what you need, and it can search for a server and add it to your config.


### PR DESCRIPTION
This PR rewrites the "Find more MCP servers" section in the Tools lesson (`09-tools.mdx`). The old content vaguely referenced "the broader MCP ecosystem" with "hundreds of servers" but didn't link anywhere useful.

The new content:
- Links directly to the [official MCP registry](https://registry.modelcontextprotocol.io) with a brief description
- Keeps the existing OpenCode MCP docs link (accurate and useful)
- Adds a tip about asking OpenCode itself to find and install servers

Closes #83.