### PR TITLE
fix: describe Desktop provider flow instead of TUI-only /connect command

### DIFF
--- a/src/content/lessons/06-models.mdx
+++ b/src/content/lessons/06-models.mdx
@@ -37,7 +37,7 @@ The specific models may change over time.
 
 These models cost nothing to use, which makes them great for learning and experimenting. But they come with tradeoffs: most lack vision support, and they tend to be less capable on complex tasks compared to paid options. If you find OpenCode struggling with something, upgrading to a better model is often the fix.
 
-To set up Zen, run `/connect`, select "OpenCode Zen", and follow the prompts.
+To set up Zen, click the model name below the prompt and then the settings button (in the terminal app, type `/connect`), select "OpenCode Zen", and follow the prompts.
 
 ## OpenCode Go
 
@@ -50,7 +50,7 @@ To set up Zen, run `/connect`, select "OpenCode Zen", and follow the prompts.
 
 Kimi K2.5 is worth calling out — it has vision support, meaning it can interpret images you paste into the conversation. This is useful for tasks like implementing a design from a screenshot, debugging a UI, or reading text from an image.
 
-To set up Go, run `/connect`, select "OpenCode Go", and follow the prompts.
+To set up Go, click the model name below the prompt and then the settings button (in the terminal app, type `/connect`), select "OpenCode Go", and follow the prompts.
 
 ## Cloudflare
 
@@ -85,7 +85,7 @@ With a smaller model, context management matters more. A few tips:
 
 ## Other providers
 
-OpenCode supports 75+ model providers. If you already use Anthropic, OpenAI, Google, or another provider, you can connect it to OpenCode. Run `/connect` and select your provider from the list.
+OpenCode supports 75+ model providers. If you already use Anthropic, OpenAI, Google, or another provider, you can connect it to OpenCode. Click the model name below the prompt and then the settings button (in the terminal app, type `/connect`) and select your provider from the list.
 
 **The latest flagship models from Anthropic and OpenAI are generally the most capable options available. If you can afford to use them, you'll get better results.**
 


### PR DESCRIPTION
This PR updates the models lesson to describe the Desktop-compatible way to connect providers. The lesson previously referenced `/connect` three times, which is a TUI slash command that doesn't exist in OpenCode Desktop.

Since the course targets Desktop users, all three references now lead with the Desktop flow (click the model name below the prompt, then the settings button) and mention `/connect` as the terminal alternative in a parenthetical.

Closes #115