### PR TITLE
refactor: migrate agentInstructions to YAML block scalars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Each lesson is an MDX file in `src/content/lessons/`. The frontmatter schema (de
 - `title`, `slug`, `description`, `order` — standard metadata
 - `agentInstructions` (required) — describes what "done" looks like and how to verify it; used by agents to evaluate and mark completion
 
-When editing lessons, keep `agentInstructions` accurate. It should describe both the verifiable end state and the steps an agent should take to confirm it.
+When editing lessons, keep `agentInstructions` accurate. It should describe both the verifiable end state and the steps an agent should take to confirm it. Always use YAML literal block scalars (`|`) for `agentInstructions`, never quoted strings. This keeps instructions readable, produces line-level diffs, and allows paragraph breaks between logical sections.
 
 ## Lesson authoring guidelines
 

--- a/src/content/exercises/01-build-a-website.mdx
+++ b/src/content/exercises/01-build-a-website.mdx
@@ -3,7 +3,49 @@ title: "Build a website"
 slug: build-a-website
 description: "Build a personal homepage with Hono and deploy it to Cloudflare Workers."
 order: 1
-agentInstructions: "Guide the student through building and deploying a personal homepage. Adapt the depth and pace to their profile (codingExperience, terminalComfort, etc.). Steps: (1) Check if Node.js is installed by running `node --version`. If not installed, help them install it — use Homebrew (`brew install node`) on macOS, or guide them to https://nodejs.org for other platforms. (2) Help them sign up for a free Cloudflare account at https://dash.cloudflare.com/sign-up if they don't have one. They can verify by running `npx wrangler whoami` — if not authenticated, run `npx wrangler login`. (3) Scaffold a new Hono project with `npm create hono@latest my-site` — select the `cloudflare-workers` template and install dependencies. (4) Set up JSX by adding `\"jsxFactory\": \"jsx\", \"jsxFragment\": \"Fragment\"` to tsconfig.json compilerOptions if not already present, rename `src/index.ts` to `src/index.tsx`, and configure JSX rendering using Hono's `hono/jsx` module. (5) Build a personal homepage — ask the student what they want on their page (name, bio, interests, links, etc.) and help them create it using Hono JSX components with Tailwind CSS via the CDN play script (`<script src=\"https://cdn.tailwindcss.com\"></script>`). Make it look good with proper typography, spacing, and color. (6) Test locally with `npm run dev` and confirm the page renders at http://localhost:8787. (7) Deploy with `npx wrangler deploy` and confirm the site is live at a .workers.dev URL. After deployment, suggest optional next steps: adding more pages, making something dynamic with Workers KV (like a visitor counter), or adding a custom domain. Verify completion by confirming the student has a working .workers.dev URL that serves their personal homepage."
+agentInstructions: |
+  Guide the student through building and deploying a personal homepage.
+  Adapt the depth and pace to their profile (codingExperience,
+  terminalComfort, etc.).
+
+  Steps:
+
+  1. Check if Node.js is installed by running `node --version`. If not
+     installed, help them install it: use Homebrew (`brew install node`)
+     on macOS, or guide them to https://nodejs.org for other platforms.
+
+  2. Help them sign up for a free Cloudflare account at
+     https://dash.cloudflare.com/sign-up if they don't have one. They can
+     verify by running `npx wrangler whoami`. If not authenticated, run
+     `npx wrangler login`.
+
+  3. Scaffold a new Hono project with
+     `npm create hono@latest my-site`: select the `cloudflare-workers`
+     template and install dependencies.
+
+  4. Set up JSX by adding `"jsxFactory": "jsx", "jsxFragment": "Fragment"`
+     to tsconfig.json compilerOptions if not already present, rename
+     `src/index.ts` to `src/index.tsx`, and configure JSX rendering using
+     Hono's `hono/jsx` module.
+
+  5. Build a personal homepage: ask the student what they want on their
+     page (name, bio, interests, links, etc.) and help them create it
+     using Hono JSX components with Tailwind CSS via the CDN play script
+     (`<script src="https://cdn.tailwindcss.com"></script>`). Make it look
+     good with proper typography, spacing, and color.
+
+  6. Test locally with `npm run dev` and confirm the page renders at
+     http://localhost:8787.
+
+  7. Deploy with `npx wrangler deploy` and confirm the site is live at a
+     .workers.dev URL.
+
+  After deployment, suggest optional next steps: adding more pages, making
+  something dynamic with Workers KV (like a visitor counter), or adding a
+  custom domain.
+
+  Verify completion by confirming the student has a working .workers.dev
+  URL that serves their personal homepage.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/exercises/02-run-ai-models.mdx
+++ b/src/content/exercises/02-run-ai-models.mdx
@@ -3,7 +3,48 @@ title: "Run AI models"
 slug: run-ai-models
 description: "Generate images and video using AI models on Replicate."
 order: 2
-agentInstructions: "This exercise requires the Replicate skill. If the student does not have it installed (check ~/.config/opencode/skills/replicate/ or ~/.agents/skills/replicate/ for a SKILL.md file), stop and help them install it first with `npx skills add https://github.com/replicate/replicate-skill`. The skill must be loaded before proceeding. Guide the student through these steps, adapting depth to their profile: (1) Check that REPLICATE_API_TOKEN is set in the environment. If not, guide them to create a Replicate account at https://replicate.com (requires a GitHub account — help them create one at https://github.com/signup if needed), then generate an API token at https://replicate.com/account/api-tokens and add `REPLICATE_API_TOKEN=r8_...` to their shell profile (~/.zshrc, ~/.bashrc, etc.) and to the current session with `export REPLICATE_API_TOKEN=r8_...`. They will need to restart OpenCode after adding the token for it to take effect. (2) Generate images with google/nano-banana-2. Start with a text-to-image prompt — ask the student what they want to create and help them write a descriptive prompt. Run the model and show the result. Then try image editing: have the student provide an existing image (photo, screenshot, anything) and use nano-banana-2 to transform it with a text prompt. Experiment with different aspect ratios and styles. (3) Generate a video from one of the images using google/veo-3.1-fast. Use the image_url input to pass one of the generated images, and write a prompt describing the motion or scene. The video takes a minute or two to generate. (4) Save the outputs locally — download the generated images and video to the student's machine. Use the Replicate skill's API knowledge to create predictions, poll for results, and handle output URLs. Do not use the Replicate CLI or Node.js SDK — work directly with the API via the skill. Fire off multiple predictions concurrently when possible. Output URLs expire after 1 hour, so download files promptly. Verify completion by confirming the student has at least one generated image and one generated video saved locally."
+agentInstructions: |
+  This exercise requires the Replicate skill. If the student does not have
+  it installed (check ~/.config/opencode/skills/replicate/ or
+  ~/.agents/skills/replicate/ for a SKILL.md file), stop and help them
+  install it first with
+  `npx skills add https://github.com/replicate/replicate-skill`. The
+  skill must be loaded before proceeding.
+
+  Guide the student through these steps, adapting depth to their profile:
+
+  1. Check that REPLICATE_API_TOKEN is set in the environment. If not,
+     guide them to create a Replicate account at https://replicate.com
+     (requires a GitHub account, help them create one at
+     https://github.com/signup if needed), then generate an API token at
+     https://replicate.com/account/api-tokens and add
+     `REPLICATE_API_TOKEN=r8_...` to their shell profile (~/.zshrc,
+     ~/.bashrc, etc.) and to the current session with
+     `export REPLICATE_API_TOKEN=r8_...`. They will need to restart
+     OpenCode after adding the token for it to take effect.
+
+  2. Generate images with google/nano-banana-2. Start with a
+     text-to-image prompt: ask the student what they want to create and
+     help them write a descriptive prompt. Run the model and show the
+     result. Then try image editing: have the student provide an existing
+     image (photo, screenshot, anything) and use nano-banana-2 to
+     transform it with a text prompt. Experiment with different aspect
+     ratios and styles.
+
+  3. Generate a video from one of the images using google/veo-3.1-fast.
+     Use the image_url input to pass one of the generated images, and
+     write a prompt describing the motion or scene. The video takes a
+     minute or two to generate.
+
+  4. Save the outputs locally: download the generated images and video to
+     the student's machine. Use the Replicate skill's API knowledge to
+     create predictions, poll for results, and handle output URLs. Do not
+     use the Replicate CLI or Node.js SDK, work directly with the API via
+     the skill. Fire off multiple predictions concurrently when possible.
+     Output URLs expire after 1 hour, so download files promptly.
+
+  Verify completion by confirming the student has at least one generated
+  image and one generated video saved locally.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/exercises/03-edit-videos.mdx
+++ b/src/content/exercises/03-edit-videos.mdx
@@ -3,7 +3,52 @@ title: "Edit videos"
 slug: edit-videos
 description: "Edit videos from the command line using FFMPEG and yt-dlp."
 order: 3
-agentInstructions: "Guide the student through video editing with FFMPEG and yt-dlp. Adapt depth to their profile. Steps: (1) Install FFMPEG and yt-dlp. On macOS use Homebrew: `brew install ffmpeg yt-dlp`. On Linux: use the system package manager (apt, dnf, etc.) or Homebrew. On Windows: guide them to download from ffmpeg.org and github.com/yt-dlp/yt-dlp. Verify both are installed by running `ffmpeg -version` and `yt-dlp --version`. (2) Find a Creative Commons video on YouTube. Teach them how: go to youtube.com, search for something interesting (nature, city, music, etc.), click Filters, and under Features select Creative Commons. Help them pick a short video (under 5 minutes is ideal). (3) Download the video using yt-dlp. Use `yt-dlp -f 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]' -o 'source.mp4' URL` to get an MP4 file. Explain what the format selector does. (4) Inspect the video with `ffprobe source.mp4` to see its resolution, duration, codecs, and frame rate. Explain the key fields in the output. (5) Extract frames at one per second: `ffmpeg -i source.mp4 -vf fps=1 frames/frame_%04d.jpg`. Create the frames/ directory first. Explain the fps filter. (6) Extract the audio track: `ffmpeg -i source.mp4 -vn -acodec copy audio.m4a` (or convert to mp3 with `-acodec libmp3lame`). Explain -vn and -acodec. (7) Extract a clip by specifying a start time and duration: `ffmpeg -i source.mp4 -ss 00:00:10 -t 5 -c copy clip.mp4`. Explain -ss, -t, and -c copy. After completing the basics, suggest creative next steps the student might try: making a GIF from the frames, adding a text watermark, creating a slow-motion or sped-up version, combining clips, or extracting a still frame at a specific timestamp. Let the student choose what sounds fun and help them do it. Verify completion by confirming the student has the source video, extracted frames directory, audio file, and video clip in their working directory."
+agentInstructions: |
+  Guide the student through video editing with FFMPEG and yt-dlp. Adapt
+  depth to their profile.
+
+  Steps:
+
+  1. Install FFMPEG and yt-dlp. On macOS use Homebrew:
+     `brew install ffmpeg yt-dlp`. On Linux: use the system package
+     manager (apt, dnf, etc.) or Homebrew. On Windows: guide them to
+     download from ffmpeg.org and github.com/yt-dlp/yt-dlp. Verify both
+     are installed by running `ffmpeg -version` and `yt-dlp --version`.
+
+  2. Find a Creative Commons video on YouTube. Teach them how: go to
+     youtube.com, search for something interesting (nature, city, music,
+     etc.), click Filters, and under Features select Creative Commons.
+     Help them pick a short video (under 5 minutes is ideal).
+
+  3. Download the video using yt-dlp. Use
+     `yt-dlp -f 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]' -o 'source.mp4' URL`
+     to get an MP4 file. Explain what the format selector does.
+
+  4. Inspect the video with `ffprobe source.mp4` to see its resolution,
+     duration, codecs, and frame rate. Explain the key fields in the
+     output.
+
+  5. Extract frames at one per second:
+     `ffmpeg -i source.mp4 -vf fps=1 frames/frame_%04d.jpg`. Create the
+     frames/ directory first. Explain the fps filter.
+
+  6. Extract the audio track:
+     `ffmpeg -i source.mp4 -vn -acodec copy audio.m4a` (or convert to
+     mp3 with `-acodec libmp3lame`). Explain -vn and -acodec.
+
+  7. Extract a clip by specifying a start time and duration:
+     `ffmpeg -i source.mp4 -ss 00:00:10 -t 5 -c copy clip.mp4`. Explain
+     -ss, -t, and -c copy.
+
+  After completing the basics, suggest creative next steps the student
+  might try: making a GIF from the frames, adding a text watermark,
+  creating a slow-motion or sped-up version, combining clips, or
+  extracting a still frame at a specific timestamp. Let the student choose
+  what sounds fun and help them do it.
+
+  Verify completion by confirming the student has the source video,
+  extracted frames directory, audio file, and video clip in their working
+  directory.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/exercises/04-transcribe-speech.mdx
+++ b/src/content/exercises/04-transcribe-speech.mdx
@@ -3,7 +3,52 @@ title: "Transcribe speech"
 slug: transcribe-speech
 description: "Transcribe audio to text locally using Whisper."
 order: 4
-agentInstructions: "Guide the student through local speech-to-text transcription using whisper-cpp. Adapt depth to their profile. Steps: (1) Install whisper-cpp and ffmpeg. On macOS: `brew install whisper-cpp ffmpeg`. On Linux: use the system package manager or build from source (https://github.com/ggerganov/whisper.cpp). Verify with `whisper-cpp --help` and `ffmpeg -version`. (2) Download a Whisper model. Use the ggml-large-v3-q5_0 model (good balance of quality and size, ~1GB): `curl -o ggml-large-v3-q5_0.bin -L 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.bin?download=true'`. Explain that Whisper has multiple model sizes and this is a quantized version of the large model. (3) Get an audio source. Offer the student three options: (a) record a short clip using their microphone — on macOS they can use QuickTime Player or `say` to generate speech, (b) if they did the Edit Videos exercise, use the audio file they already extracted, (c) download a sample — a podcast clip, speech recording, or any audio with speech. Help them with whichever option they choose. (4) Convert the audio to 16kHz WAV format (required by whisper-cpp): `ffmpeg -i input.mp3 -ar 16000 input.wav`. Explain why 16kHz is needed. (5) Run transcription: `whisper-cpp -m ggml-large-v3-q5_0.bin input.wav --output-txt`. This produces a timestamped transcript on stdout and saves a plain text file. Walk through the output together. (6) Try a different output format — SRT subtitles (`--output-srt`) or VTT (`--output-vtt`). Explain what these formats are used for (video subtitles, closed captions). After the basics, mention that whisper-cpp can also translate from other languages to English using the `--translate` flag — if the student has audio in another language or wants to try it, help them do so. Verify completion by confirming the student has a transcription output file (txt, srt, or vtt) in their working directory."
+agentInstructions: |
+  Guide the student through local speech-to-text transcription using
+  whisper-cpp. Adapt depth to their profile.
+
+  Steps:
+
+  1. Install whisper-cpp and ffmpeg. On macOS:
+     `brew install whisper-cpp ffmpeg`. On Linux: use the system package
+     manager or build from source
+     (https://github.com/ggerganov/whisper.cpp). Verify with
+     `whisper-cpp --help` and `ffmpeg -version`.
+
+  2. Download a Whisper model. Use the ggml-large-v3-q5_0 model (good
+     balance of quality and size, ~1GB):
+     `curl -o ggml-large-v3-q5_0.bin -L 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.bin?download=true'`.
+     Explain that Whisper has multiple model sizes and this is a quantized
+     version of the large model.
+
+  3. Get an audio source. Offer the student three options:
+     (a) Record a short clip using their microphone. On macOS they can use
+         QuickTime Player or `say` to generate speech.
+     (b) If they did the Edit Videos exercise, use the audio file they
+         already extracted.
+     (c) Download a sample: a podcast clip, speech recording, or any
+         audio with speech.
+     Help them with whichever option they choose.
+
+  4. Convert the audio to 16kHz WAV format (required by whisper-cpp):
+     `ffmpeg -i input.mp3 -ar 16000 input.wav`. Explain why 16kHz is
+     needed.
+
+  5. Run transcription:
+     `whisper-cpp -m ggml-large-v3-q5_0.bin input.wav --output-txt`. This
+     produces a timestamped transcript on stdout and saves a plain text
+     file. Walk through the output together.
+
+  6. Try a different output format: SRT subtitles (`--output-srt`) or VTT
+     (`--output-vtt`). Explain what these formats are used for (video
+     subtitles, closed captions).
+
+  After the basics, mention that whisper-cpp can also translate from other
+  languages to English using the `--translate` flag. If the student has
+  audio in another language or wants to try it, help them do so.
+
+  Verify completion by confirming the student has a transcription output
+  file (txt, srt, or vtt) in their working directory.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/exercises/05-drive-a-browser.mdx
+++ b/src/content/exercises/05-drive-a-browser.mdx
@@ -3,7 +3,47 @@ title: "Drive a browser"
 slug: drive-a-browser
 description: "Automate your real browser using Chrome DevTools MCP."
 order: 5
-agentInstructions: "Guide the student through setting up and using Chrome DevTools MCP to automate their real browser from OpenCode. Adapt depth to their profile. Steps: (1) Enable remote debugging in Chrome. Have the student navigate to chrome://inspect/#remote-debugging in Chrome and enable the remote debugging feature. (2) Add the Chrome DevTools MCP server to the student's OpenCode global config (~/.config/opencode/opencode.jsonc). Add a `mcp` section if it doesn't exist, with: `\"chrome-devtools\": { \"type\": \"local\", \"command\": [\"npx\", \"-y\", \"chrome-devtools-mcp@latest\", \"--autoConnect\"] }`. The student needs to restart OpenCode after adding this. (3) Recommend starting in Plan Mode for safety — the agent should describe what it intends to do before acting in the browser. Show the student how to switch to Plan Mode in OpenCode. (4) Start with something simple: take a screenshot of whatever tab the student has open. This verifies the connection works. (5) Try a Lighthouse audit on a page the student has open — run an accessibility or performance audit and review the results together. (6) Ask the student what they want to automate. Give them ideas: extract data from a page they're logged into, fill out a form, navigate through a multi-step workflow, compare prices across tabs, summarize a long article, check their bank or school portal. The key insight is that their agent inherits their existing browser session — they're already logged in everywhere, so sites that were never designed for automation become automatable. Help them accomplish whatever they want to try. (7) After completing at least one meaningful browser automation task, discuss what went well and what the limitations are. Verify completion by confirming the student has successfully used the Chrome DevTools MCP to perform at least one browser automation task (screenshot, audit, data extraction, form interaction, etc.)."
+agentInstructions: |
+  Guide the student through setting up and using Chrome DevTools MCP to
+  automate their real browser from OpenCode. Adapt depth to their profile.
+
+  Steps:
+
+  1. Enable remote debugging in Chrome. Have the student navigate to
+     chrome://inspect/#remote-debugging in Chrome and enable the remote
+     debugging feature.
+
+  2. Add the Chrome DevTools MCP server to the student's OpenCode global
+     config (~/.config/opencode/opencode.jsonc). Add a `mcp` section if
+     it doesn't exist, with:
+     `"chrome-devtools": { "type": "local", "command": ["npx", "-y", "chrome-devtools-mcp@latest", "--autoConnect"] }`.
+     The student needs to restart OpenCode after adding this.
+
+  3. Recommend starting in Plan Mode for safety: the agent should describe
+     what it intends to do before acting in the browser. Show the student
+     how to switch to Plan Mode in OpenCode.
+
+  4. Start with something simple: take a screenshot of whatever tab the
+     student has open. This verifies the connection works.
+
+  5. Try a Lighthouse audit on a page the student has open: run an
+     accessibility or performance audit and review the results together.
+
+  6. Ask the student what they want to automate. Give them ideas: extract
+     data from a page they're logged into, fill out a form, navigate
+     through a multi-step workflow, compare prices across tabs, summarize
+     a long article, check their bank or school portal. The key insight is
+     that their agent inherits their existing browser session, so they're
+     already logged in everywhere, and sites that were never designed for
+     automation become automatable. Help them accomplish whatever they want
+     to try.
+
+  7. After completing at least one meaningful browser automation task,
+     discuss what went well and what the limitations are.
+
+  Verify completion by confirming the student has successfully used the
+  Chrome DevTools MCP to perform at least one browser automation task
+  (screenshot, audit, data extraction, form interaction, etc.).
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/exercises/06-post-to-social-media.mdx
+++ b/src/content/exercises/06-post-to-social-media.mdx
@@ -3,7 +3,46 @@ title: "Post to social media"
 slug: post-to-social-media
 description: "Brainstorm and draft social media posts using Typefully."
 order: 6
-agentInstructions: "This exercise requires the Typefully skill. If the student does not have it installed (check ~/.config/opencode/skills/typefully/ or ~/.agents/skills/typefully/ for a SKILL.md file), stop and help them install it first with `npx skills add typefully/agent-skills`. The skill must be loaded before proceeding. Guide the student through these steps, adapting depth to their profile: (1) Check that TYPEFULLY_API_KEY is set in the environment. If not, guide them to create a free Typefully account at https://typefully.com (they can sign up with Google, X/Twitter, or LinkedIn — no credit card needed). After signing up, they should connect at least one social platform (X, LinkedIn, Threads, Bluesky, or Mastodon). Then generate an API key at https://typefully.com/?settings=api and add `TYPEFULLY_API_KEY=your_key_here` to their shell profile (~/.zshrc, ~/.bashrc, etc.) and to the current session with `export TYPEFULLY_API_KEY=your_key_here`. They will need to restart OpenCode after adding the key for it to take effect. (2) Brainstorm a post with the student. Ask what they want to post about — it could be something they learned recently, a project they're working on, an opinion, a question, anything. Help them shape the idea into a concise, engaging post. Adapt the tone to what feels natural for them. (3) Create the post as a Typefully draft using the skill. The draft will appear in their Typefully account at typefully.com, where they can review it, edit it, choose which platforms to publish to, and schedule or publish it. Do not publish directly — always create as a draft so the student has a chance to review. (4) Optionally, try creating a thread — a multi-post series on a topic. Threads work well for explaining a process, telling a story, or breaking down a complex idea. Help the student outline the thread and create it as a draft. (5) Verify completion by confirming the student has at least one draft visible in their Typefully account (they can check at typefully.com). Ask the student to confirm they can see the draft."
+agentInstructions: |
+  This exercise requires the Typefully skill. If the student does not have
+  it installed (check ~/.config/opencode/skills/typefully/ or
+  ~/.agents/skills/typefully/ for a SKILL.md file), stop and help them
+  install it first with `npx skills add typefully/agent-skills`. The skill
+  must be loaded before proceeding.
+
+  Guide the student through these steps, adapting depth to their profile:
+
+  1. Check that TYPEFULLY_API_KEY is set in the environment. If not, guide
+     them to create a free Typefully account at https://typefully.com
+     (they can sign up with Google, X/Twitter, or LinkedIn, no credit card
+     needed). After signing up, they should connect at least one social
+     platform (X, LinkedIn, Threads, Bluesky, or Mastodon). Then generate
+     an API key at https://typefully.com/?settings=api and add
+     `TYPEFULLY_API_KEY=your_key_here` to their shell profile (~/.zshrc,
+     ~/.bashrc, etc.) and to the current session with
+     `export TYPEFULLY_API_KEY=your_key_here`. They will need to restart
+     OpenCode after adding the key for it to take effect.
+
+  2. Brainstorm a post with the student. Ask what they want to post
+     about: it could be something they learned recently, a project they're
+     working on, an opinion, a question, anything. Help them shape the
+     idea into a concise, engaging post. Adapt the tone to what feels
+     natural for them.
+
+  3. Create the post as a Typefully draft using the skill. The draft will
+     appear in their Typefully account at typefully.com, where they can
+     review it, edit it, choose which platforms to publish to, and
+     schedule or publish it. Do not publish directly: always create as a
+     draft so the student has a chance to review.
+
+  4. Optionally, try creating a thread: a multi-post series on a topic.
+     Threads work well for explaining a process, telling a story, or
+     breaking down a complex idea. Help the student outline the thread and
+     create it as a draft.
+
+  5. Verify completion by confirming the student has at least one draft
+     visible in their Typefully account (they can check at
+     typefully.com). Ask the student to confirm they can see the draft.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/exercises/07-use-git-and-github.mdx
+++ b/src/content/exercises/07-use-git-and-github.mdx
@@ -3,7 +3,56 @@ title: "Use Git and GitHub"
 slug: use-git-and-github
 description: "Track and manage file changes with Git and GitHub Desktop."
 order: 7
-agentInstructions: "Guide the student through using Git and GitHub to track project changes. Adapt depth to their profile. Steps: (1) Check if Git is installed by running `git --version`. If not, recommend installing GitHub Desktop from https://desktop.github.com/ — it bundles Git, helps create a GitHub account, and authenticates the CLI automatically. If the student prefers, they can install Git directly: `brew install git` on macOS, or download from https://git-scm.com for other platforms. (2) Explain what Git is — a version control system that records every change to every file. Emphasize that Git is useful even locally with no remote: every commit is a snapshot you can return to, so nothing is ever truly lost. (3) Explain what GitHub is — a cloud platform for hosting Git repositories, backing up projects, collaborating, and sharing work. (4) Create or navigate to a project folder and initialize a Git repository with `git init`. Explain what this does (creates a hidden .git directory that stores the project's history). (5) Have the student create or edit a file, then walk them through the staging and commit workflow: `git add <file>`, `git commit -m \"message\"`. Explain what staging is and why commits need messages. (6) Make another change and show the diff: `git diff` on the command line, or use GitHub Desktop to visualize what changed. This is the key insight — when OpenCode edits files, Git lets you see exactly what was added, removed, or modified. (7) Help them create a repository on GitHub (via GitHub Desktop or `gh repo create`) and push their commits. Let them choose public or private. (8) Introduce branches: create a branch with `git checkout -b experiment`, make a change, commit it, then switch back to the main branch with `git checkout main` to show the change disappears. Explain this as a way to try things without affecting working code. After the core steps, suggest next steps: writing a `.gitignore` file, making a pull request, or exploring the repository on github.com. Verify completion by confirming the student has a local Git repository with at least two commits and has pushed it to GitHub."
+agentInstructions: |
+  Guide the student through using Git and GitHub to track project changes.
+  Adapt depth to their profile.
+
+  Steps:
+
+  1. Check if Git is installed by running `git --version`. If not,
+     recommend installing GitHub Desktop from https://desktop.github.com/,
+     which bundles Git, helps create a GitHub account, and authenticates
+     the CLI automatically. If the student prefers, they can install Git
+     directly: `brew install git` on macOS, or download from
+     https://git-scm.com for other platforms.
+
+  2. Explain what Git is: a version control system that records every
+     change to every file. Emphasize that Git is useful even locally with
+     no remote: every commit is a snapshot you can return to, so nothing
+     is ever truly lost.
+
+  3. Explain what GitHub is: a cloud platform for hosting Git
+     repositories, backing up projects, collaborating, and sharing work.
+
+  4. Create or navigate to a project folder and initialize a Git
+     repository with `git init`. Explain what this does (creates a hidden
+     .git directory that stores the project's history).
+
+  5. Have the student create or edit a file, then walk them through the
+     staging and commit workflow: `git add <file>`,
+     `git commit -m "message"`. Explain what staging is and why commits
+     need messages.
+
+  6. Make another change and show the diff: `git diff` on the command
+     line, or use GitHub Desktop to visualize what changed. This is the
+     key insight: when OpenCode edits files, Git lets you see exactly what
+     was added, removed, or modified.
+
+  7. Help them create a repository on GitHub (via GitHub Desktop or
+     `gh repo create`) and push their commits. Let them choose public or
+     private.
+
+  8. Introduce branches: create a branch with
+     `git checkout -b experiment`, make a change, commit it, then switch
+     back to the main branch with `git checkout main` to show the change
+     disappears. Explain this as a way to try things without affecting
+     working code.
+
+  After the core steps, suggest next steps: writing a `.gitignore` file,
+  making a pull request, or exploring the repository on github.com.
+
+  Verify completion by confirming the student has a local Git repository
+  with at least two commits and has pushed it to GitHub.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/lessons/01-installation.mdx
+++ b/src/content/lessons/01-installation.mdx
@@ -4,7 +4,11 @@ slug: installation
 description: "Check your system and install OpenCode Desktop."
 order: 1
 quiz: false
-agentInstructions: "If the student is talking to you through OpenCode Desktop, they have already completed this lesson. Otherwise, confirm they have a supported OS (macOS, Windows, or Linux), have installed OpenCode Desktop, can launch it, and have sent at least one prompt successfully."
+agentInstructions: |
+  If the student is talking to you through OpenCode Desktop, they have
+  already completed this lesson. Otherwise, confirm they have a supported
+  OS (macOS, Windows, or Linux), have installed OpenCode Desktop, can
+  launch it, and have sent at least one prompt successfully.
 ---
 
 In this course we'll be using **OpenCode Desktop** — a native app with a [GUI](/glossary#gui) (graphical user interface) you interact with using your mouse and keyboard. If you've used apps like ChatGPT or Claude, this chat-based interface should feel pretty familiar to you.

--- a/src/content/lessons/03-configuration.mdx
+++ b/src/content/lessons/03-configuration.mdx
@@ -5,7 +5,64 @@ description: "Create a global configuration file for OpenCode."
 order: 3
 quiz: true
 modifiesGlobalConfig: true
-agentInstructions: "Cover these four topics: (1) what the global config file is and why it applies to all OpenCode sessions across every project on the machine, (2) where the config file lives — ~/.config/opencode/opencode.jsonc on macOS/Linux, C:\\Users\\<Name>\\.config\\opencode\\opencode.jsonc on Windows, (3) what \"default_agent\": \"plan\" does — it starts every new session in Plan mode, which is read-only and safe; the student can switch to Build mode when they're ready to make changes, (4) permission basics and the instructions URL — \"*\": \"allow\" lets most actions through automatically; \"external_directory\": \"ask\" means OpenCode will pause and ask before touching files outside the project directory (this is the default, but setting it explicitly makes the config self-documenting); the bash object adds \"ask\" rules for destructive commands like rm and rmdir so OpenCode pauses before running them; the \"instructions\" array loads the student's personal OpenCode School URL ({origin}/api/instructions/{studentId}) so OpenCode always knows who they are. CRITICAL — PROTECTING THE STUDENT'S GLOBAL OPENCODE CONFIG: If ~/.config/opencode/opencode.jsonc (or opencode.json) already exists, you MUST: (a) read it first and store its full contents, (b) create a timestamped backup copy (e.g. opencode.jsonc.backup-2025-01-15T10-30-00) in the same directory, (c) tell the student where the backup is so they can restore it if needed. NEVER use the Write tool to replace the student's existing global config wholesale. Instead, use the Edit tool to make surgical changes — add missing keys, append to arrays, etc. If no global config file exists yet, you may create one from scratch. If the student explicitly asks you to overwrite their global config, still create a backup first and mention its path. This protection applies only to the student's global OpenCode config file, not to other files created during lessons. After every write or edit to the config file, re-read it and validate it is well-formed JSONC before proceeding. After teaching and quizzing, verify completion by reading ~/.config/opencode/opencode.jsonc (or ~/.config/opencode/opencode.json if the .jsonc file does not exist) and confirming it contains \"default_agent\": \"plan\", a \"permission\" object with \"*\": \"allow\", \"external_directory\": \"ask\", and at least one \"ask\" rule inside a bash object (e.g. \"rm *\": \"ask\"), and an \"instructions\" array that includes the student's personal OpenCode School instructions URL ({origin}/api/instructions/{studentId} with their actual student ID). Either file extension is acceptable. Config changes require restarting OpenCode to take effect. After verifying, instruct the student to quit OpenCode Desktop so the new config takes effect next time they open it."
+agentInstructions: |
+  Cover these four topics:
+
+  1. What the global config file is and why it applies to all OpenCode
+     sessions across every project on the machine.
+
+  2. Where the config file lives: ~/.config/opencode/opencode.jsonc on
+     macOS/Linux, C:\Users\<Name>\.config\opencode\opencode.jsonc on
+     Windows.
+
+  3. What "default_agent": "plan" does: it starts every new session in
+     Plan mode, which is read-only and safe. The student can switch to
+     Build mode when they're ready to make changes.
+
+  4. Permission basics and the instructions URL: "*": "allow" lets most
+     actions through automatically. "external_directory": "ask" means
+     OpenCode will pause and ask before touching files outside the project
+     directory (this is the default, but setting it explicitly makes the
+     config self-documenting). The bash object adds "ask" rules for
+     destructive commands like rm and rmdir so OpenCode pauses before
+     running them. The "instructions" array loads the student's personal
+     OpenCode School URL ({origin}/api/instructions/{studentId}) so
+     OpenCode always knows who they are.
+
+  CRITICAL: PROTECTING THE STUDENT'S GLOBAL OPENCODE CONFIG
+
+  If ~/.config/opencode/opencode.jsonc (or opencode.json) already exists,
+  you MUST:
+  (a) Read it first and store its full contents.
+  (b) Create a timestamped backup copy (e.g.
+      opencode.jsonc.backup-2025-01-15T10-30-00) in the same directory.
+  (c) Tell the student where the backup is so they can restore it if
+      needed.
+
+  NEVER use the Write tool to replace the student's existing global config
+  wholesale. Instead, use the Edit tool to make surgical changes: add
+  missing keys, append to arrays, etc. If no global config file exists
+  yet, you may create one from scratch. If the student explicitly asks you
+  to overwrite their global config, still create a backup first and
+  mention its path. This protection applies only to the student's global
+  OpenCode config file, not to other files created during lessons.
+
+  After every write or edit to the config file, re-read it and validate it
+  is well-formed JSONC before proceeding.
+
+  After teaching and quizzing, verify completion by reading
+  ~/.config/opencode/opencode.jsonc (or ~/.config/opencode/opencode.json
+  if the .jsonc file does not exist) and confirming it contains:
+  - "default_agent": "plan"
+  - A "permission" object with "*": "allow", "external_directory": "ask",
+    and at least one "ask" rule inside a bash object (e.g. "rm *": "ask")
+  - An "instructions" array that includes the student's personal OpenCode
+    School instructions URL ({origin}/api/instructions/{studentId} with
+    their actual student ID)
+
+  Either file extension is acceptable. Config changes require restarting
+  OpenCode to take effect. After verifying, instruct the student to quit
+  OpenCode Desktop so the new config takes effect next time they open it.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/lessons/04-permissions.mdx
+++ b/src/content/lessons/04-permissions.mdx
@@ -5,7 +5,36 @@ description: "Control what OpenCode can and can't do without asking."
 order: 4
 quiz: true
 modifiesGlobalConfig: true
-agentInstructions: "Cover these four topics: (1) the three permission levels — allow (runs immediately), ask (pauses for approval), and deny (blocked entirely); the student already has ask rules for rm and rmdir from the Configuration lesson, so build on that foundation, (2) git-specific guardrails — adding \"git push *\": \"ask\" and \"git checkout *\": \"ask\" inside the bash object to prevent accidental pushes to remote repos and discarding uncommitted changes without confirmation, (3) the external_directory permission — it controls access to paths outside the project working directory, defaults to \"ask\", and can be configured with path patterns using ~ or $HOME (e.g. \"~/projects/**\": \"allow\"), (4) per-project permissions — the student can create .opencode/opencode.jsonc in any project directory to override their global permissions for that project; useful for tightening or loosening rules in specific repos. After every write or edit to the config file, re-read it and validate it is well-formed JSONC before proceeding. After teaching and quizzing, verify completion by reading ~/.config/opencode/opencode.jsonc and confirming the bash object has at least one new granular rule beyond what was set up in the Configuration lesson — e.g. a \"git push *\": \"ask\" or \"git checkout *\": \"ask\" rule."
+agentInstructions: |
+  Cover these four topics:
+
+  1. The three permission levels: allow (runs immediately), ask (pauses
+     for approval), and deny (blocked entirely). The student already has
+     ask rules for rm and rmdir from the Configuration lesson, so build
+     on that foundation.
+
+  2. Git-specific guardrails: adding "git push *": "ask" and
+     "git checkout *": "ask" inside the bash object to prevent accidental
+     pushes to remote repos and discarding uncommitted changes without
+     confirmation.
+
+  3. The external_directory permission: it controls access to paths
+     outside the project working directory, defaults to "ask", and can be
+     configured with path patterns using ~ or $HOME (e.g.
+     "~/projects/**": "allow").
+
+  4. Per-project permissions: the student can create
+     .opencode/opencode.jsonc in any project directory to override their
+     global permissions for that project. Useful for tightening or
+     loosening rules in specific repos.
+
+  After every write or edit to the config file, re-read it and validate it
+  is well-formed JSONC before proceeding.
+
+  After teaching and quizzing, verify completion by reading
+  ~/.config/opencode/opencode.jsonc and confirming the bash object has at
+  least one new granular rule beyond what was set up in the Configuration
+  lesson, e.g. a "git push *": "ask" or "git checkout *": "ask" rule.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/lessons/05-instructions.mdx
+++ b/src/content/lessons/05-instructions.mdx
@@ -4,7 +4,27 @@ slug: instructions
 description: "Write custom instructions that OpenCode follows in every session."
 order: 5
 quiz: true
-agentInstructions: "Cover these four topics: (1) what AGENTS.md does — it gives OpenCode standing instructions that apply to every session, (2) the difference between the global file (~/.config/opencode/AGENTS.md) and a project-level file (AGENTS.md in a project root) — global is personal and not committed to git, project-level is shared with teammates, (3) what makes a good custom instruction — specific, actionable rules like preferred languages, commit message style, or safety guardrails, (4) how OpenCode loads the file — it reads both global and project AGENTS.md at session start, with project rules layered on top of global ones. After teaching and quizzing, verify completion by reading ~/.config/opencode/AGENTS.md and confirming it exists with at least one meaningful custom instruction (not just a placeholder or empty file)."
+agentInstructions: |
+  Cover these four topics:
+
+  1. What AGENTS.md does: it gives OpenCode standing instructions that
+     apply to every session.
+
+  2. The difference between the global file (~/.config/opencode/AGENTS.md)
+     and a project-level file (AGENTS.md in a project root): global is
+     personal and not committed to git, project-level is shared with
+     teammates.
+
+  3. What makes a good custom instruction: specific, actionable rules like
+     preferred languages, commit message style, or safety guardrails.
+
+  4. How OpenCode loads the file: it reads both global and project
+     AGENTS.md at session start, with project rules layered on top of
+     global ones.
+
+  After teaching and quizzing, verify completion by reading
+  ~/.config/opencode/AGENTS.md and confirming it exists with at least one
+  meaningful custom instruction (not just a placeholder or empty file).
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/lessons/06-models.mdx
+++ b/src/content/lessons/06-models.mdx
@@ -4,7 +4,43 @@ slug: models
 description: "Choose and configure AI models in OpenCode."
 order: 6
 quiz: true
-agentInstructions: "Cover these five topics: (1) the cost vs. capability tradeoff — state-of-the-art models from Anthropic and OpenAI deliver better results on complex tasks but cost money per request; open-source alternatives are faster and cheaper but less capable; using OpenCode well means finding the right balance for what you're trying to do, (2) where the current model is shown in OpenCode (just below the text input) and how to change it — click the model name or type /model to open the model picker, (3) the free built-in models via OpenCode Zen and their limitations — most lack vision support and may be less capable on complex tasks, (4) Cloudflare as a model provider — AI Gateway is a proxy that routes requests to providers like OpenAI and Anthropic through a single Cloudflare bill via Unified Billing so you don't need separate API keys for each provider; Workers AI is a separate option that runs open-source models directly on Cloudflare's network but is more limited since it only hosts certain models; both are useful if you already have a Cloudflare account, (5) context windows — what they are (the amount of text a model can see at once, measured in tokens), how they differ between models (large flagship models often have 128K–1M token windows, while smaller/cheaper models may have 8K–32K), why it matters (as a conversation grows, older context can be lost or the model slows down), what compaction is (OpenCode summarizes old context to free up space when the window fills), and the practical guidance: with big models you rarely need to worry; with smaller models, keep sessions focused, start fresh sessions for new tasks, and watch for signs the model is losing track. This lesson has no file-system verification step — completion is confirmed by the student demonstrating understanding through the quiz."
+agentInstructions: |
+  Cover these five topics:
+
+  1. The cost vs. capability tradeoff: state-of-the-art models from
+     Anthropic and OpenAI deliver better results on complex tasks but cost
+     money per request. Open-source alternatives are faster and cheaper
+     but less capable. Using OpenCode well means finding the right balance
+     for what you're trying to do.
+
+  2. Where the current model is shown in OpenCode (just below the text
+     input) and how to change it: click the model name or type /model to
+     open the model picker.
+
+  3. The free built-in models via OpenCode Zen and their limitations: most
+     lack vision support and may be less capable on complex tasks.
+
+  4. Cloudflare as a model provider: AI Gateway is a proxy that routes
+     requests to providers like OpenAI and Anthropic through a single
+     Cloudflare bill via Unified Billing, so you don't need separate API
+     keys for each provider. Workers AI is a separate option that runs
+     open-source models directly on Cloudflare's network but is more
+     limited since it only hosts certain models. Both are useful if you
+     already have a Cloudflare account.
+
+  5. Context windows: what they are (the amount of text a model can see at
+     once, measured in tokens), how they differ between models (large
+     flagship models often have 128K-1M token windows, while
+     smaller/cheaper models may have 8K-32K), why it matters (as a
+     conversation grows, older context can be lost or the model slows
+     down), what compaction is (OpenCode summarizes old context to free up
+     space when the window fills), and practical guidance: with big models
+     you rarely need to worry; with smaller models, keep sessions focused,
+     start fresh sessions for new tasks, and watch for signs the model is
+     losing track.
+
+  This lesson has no file-system verification step. Completion is
+  confirmed by the student demonstrating understanding through the quiz.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/lessons/07-commands.mdx
+++ b/src/content/lessons/07-commands.mdx
@@ -4,7 +4,32 @@ slug: commands
 description: "Create custom slash commands for tasks you run repeatedly."
 order: 7
 quiz: true
-agentInstructions: "Cover these four topics: (1) what custom commands are — reusable slash commands that send a saved prompt to the model when invoked with /command-name, (2) the two ways to define them — markdown files in ~/.config/opencode/commands/ (global) or .opencode/commands/ (per-project), or as JSON entries in opencode.jsonc under the \"command\" key, (3) the $ARGUMENTS placeholder — how to pass arguments when invoking a command so the same command can be adapted at runtime, (4) the optional agent and model frontmatter options — you can pin a command to a specific agent or model, with a link to the docs for full details. After teaching and quizzing, verify completion by reading ~/.config/opencode/commands/summarize.md and confirming it exists with a description in the frontmatter and a prompt in the body. After marking the lesson complete, do NOT suggest moving on to the next lesson. Instead, tell the student: commands are loaded at startup, so they need to quit OpenCode Desktop and reopen it to pick up the new command — and they can move on to the next lesson after restarting."
+agentInstructions: |
+  Cover these four topics:
+
+  1. What custom commands are: reusable slash commands that send a saved
+     prompt to the model when invoked with /command-name.
+
+  2. The two ways to define them: markdown files in
+     ~/.config/opencode/commands/ (global) or .opencode/commands/
+     (per-project), or as JSON entries in opencode.jsonc under the
+     "command" key.
+
+  3. The $ARGUMENTS placeholder: how to pass arguments when invoking a
+     command so the same command can be adapted at runtime.
+
+  4. The optional agent and model frontmatter options: you can pin a
+     command to a specific agent or model, with a link to the docs for
+     full details.
+
+  After teaching and quizzing, verify completion by reading
+  ~/.config/opencode/commands/summarize.md and confirming it exists with a
+  description in the frontmatter and a prompt in the body.
+
+  After marking the lesson complete, do NOT suggest moving on to the next
+  lesson. Instead, tell the student: commands are loaded at startup, so
+  they need to quit OpenCode Desktop and reopen it to pick up the new
+  command, and they can move on to the next lesson after restarting.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/lessons/08-skills.mdx
+++ b/src/content/lessons/08-skills.mdx
@@ -4,7 +4,35 @@ slug: skills
 description: "Install reusable agent behaviors with Skills."
 order: 8
 quiz: true
-agentInstructions: "Cover these four topics: (1) what skills are — reusable instruction sets in SKILL.md files, originally created by Anthropic, now an open standard at agentskills.io, supported by 40+ AI tools including Claude Code, Codex, and Cursor, (2) how agents use skills — two ways: automatically when a task matches a skill's description, or manually when the user explicitly invokes a skill by name, (3) what a skill can contain — at minimum a SKILL.md file with name and description frontmatter plus instructions; can also bundle scripts, reference docs, templates, and other assets in the same folder, (4) why npx skills is the recommended install method — it installs to all your AI tools at once from a single command, rather than manually copying files for each tool. After teaching and quizzing, verify completion by checking that at least one skill directory exists under ~/.config/opencode/skills/ or ~/.agents/skills/ and contains a SKILL.md file. After marking the lesson complete, do NOT suggest moving on to the next lesson. Instead, tell the student: skills are loaded at startup, so they need to quit OpenCode and reopen it for the newly installed skills to take effect. They can verify skills loaded by prompting 'list installed skills'. They can move on to the next lesson after restarting."
+agentInstructions: |
+  Cover these four topics:
+
+  1. What skills are: reusable instruction sets in SKILL.md files,
+     originally created by Anthropic, now an open standard at
+     agentskills.io, supported by 40+ AI tools including Claude Code,
+     Codex, and Cursor.
+
+  2. How agents use skills: two ways: automatically when a task matches a
+     skill's description, or manually when the user explicitly invokes a
+     skill by name.
+
+  3. What a skill can contain: at minimum a SKILL.md file with name and
+     description frontmatter plus instructions. Can also bundle scripts,
+     reference docs, templates, and other assets in the same folder.
+
+  4. Why `npx skills` is the recommended install method: it installs to
+     all your AI tools at once from a single command, rather than manually
+     copying files for each tool.
+
+  After teaching and quizzing, verify completion by checking that at least
+  one skill directory exists under ~/.config/opencode/skills/ or
+  ~/.agents/skills/ and contains a SKILL.md file.
+
+  After marking the lesson complete, do NOT suggest moving on to the next
+  lesson. Instead, tell the student: skills are loaded at startup, so they
+  need to quit OpenCode and reopen it for the newly installed skills to
+  take effect. They can verify skills loaded by prompting "list installed
+  skills". They can move on to the next lesson after restarting.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/lessons/09-tools.mdx
+++ b/src/content/lessons/09-tools.mdx
@@ -5,7 +5,41 @@ description: "Extend OpenCode with external tools and MCP servers."
 order: 9
 quiz: true
 modifiesGlobalConfig: true
-agentInstructions: "Cover these four topics: (1) what tools are — functions an AI can call to do things beyond generating text, sometimes called 'function calling' or 'tool use'; this is what makes OpenCode an agent rather than a chatbot, (2) what MCP is — Model Context Protocol, an open standard for connecting AI to external tools; two kinds of servers: local (runs on your machine, typically via npx) and remote (runs in the cloud, connected by URL); you can edit the config yourself or just ask OpenCode to add servers for you, (3) public vs. authenticated servers — some MCP servers require no credentials and work immediately; others require an API token in your config or an OAuth browser flow to authenticate, (4) the /mcp command and context — use /mcp in OpenCode to see configured servers and their connection status; good practice after installing a new server to confirm it's connected and authenticated; also note that each MCP server adds tools to the context window, so be selective about how many you enable. After every write or edit to the config file, re-read it and validate it is well-formed JSONC before proceeding. After teaching and quizzing, verify completion by reading ~/.config/opencode/opencode.jsonc and confirming an 'mcp' block exists with at least one server entry. After marking the lesson complete, do NOT suggest moving on to the next lesson. Instead, tell the student: MCP servers are connected at startup, so they need to quit OpenCode Desktop and reopen it for the new server to be available — and they can move on to the next lesson after restarting."
+agentInstructions: |
+  Cover these four topics:
+
+  1. What tools are: functions an AI can call to do things beyond
+     generating text, sometimes called "function calling" or "tool use".
+     This is what makes OpenCode an agent rather than a chatbot.
+
+  2. What MCP is: Model Context Protocol, an open standard for connecting
+     AI to external tools. Two kinds of servers: local (runs on your
+     machine, typically via npx) and remote (runs in the cloud, connected
+     by URL). You can edit the config yourself or just ask OpenCode to add
+     servers for you.
+
+  3. Public vs. authenticated servers: some MCP servers require no
+     credentials and work immediately. Others require an API token in your
+     config or an OAuth browser flow to authenticate.
+
+  4. The /mcp command and context: use /mcp in OpenCode to see configured
+     servers and their connection status. Good practice after installing a
+     new server to confirm it's connected and authenticated. Also note
+     that each MCP server adds tools to the context window, so be
+     selective about how many you enable.
+
+  After every write or edit to the config file, re-read it and validate it
+  is well-formed JSONC before proceeding.
+
+  After teaching and quizzing, verify completion by reading
+  ~/.config/opencode/opencode.jsonc and confirming an "mcp" block exists
+  with at least one server entry.
+
+  After marking the lesson complete, do NOT suggest moving on to the next
+  lesson. Instead, tell the student: MCP servers are connected at startup,
+  so they need to quit OpenCode Desktop and reopen it for the new server
+  to be available, and they can move on to the next lesson after
+  restarting.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/lessons/10-plugins.mdx
+++ b/src/content/lessons/10-plugins.mdx
@@ -4,7 +4,48 @@ slug: plugins
 description: "Extend OpenCode with plugins that add tools, hook into events, and integrate external services."
 order: 10
 quiz: true
-agentInstructions: "Cover these four topics: (1) what plugins are — JavaScript or TypeScript modules that extend OpenCode by hooking into events, adding custom tools, or integrating external services; they go beyond MCP servers (covered in the Tools lesson) by letting you modify OpenCode's behavior itself rather than just exposing external tools; reference the Tools lesson so the student sees the progression, (2) where plugins live — two scopes: project-level in .opencode/plugins/ and global in ~/.config/opencode/plugins/; can also install npm packages via the plugin array in opencode.json; dependencies go in a package.json in the same config directory and OpenCode runs bun install automatically at startup, (3) what plugins can do — subscribe to lifecycle events like session.idle or tool.execute.before; add custom tools using the tool() helper from @opencode-ai/plugin with Zod schemas for arguments; inject environment variables; modify tool behavior with before/after hooks; plugins can also ship companion skills that inject workflow guidance into the agent prompt, (4) installing a real plugin — walk through installing the Replicate plugin as a hands-on example: first get a Replicate API token from replicate.com/account/api-tokens, add export REPLICATE_API_TOKEN=r8_your_token_here to their shell profile (.bashrc or .zshrc), then run the quick-install script with curl -sSL https://raw.githubusercontent.com/lucataco/replicate-opencode-plugin/main/install.sh | bash from the project root, which downloads the plugin, a companion skill, and a package.json into the .opencode/ directory; after restarting OpenCode, verify by asking 'What is my Replicate username?' and confirming the agent calls replicate_whoami and returns account info. After teaching and quizzing, verify completion by reading .opencode/plugins/replicate.ts and confirming it exists. After marking the lesson complete, do NOT suggest moving on to the next lesson. Instead, tell the student: plugins are loaded at startup, so they need to quit OpenCode Desktop and reopen it for the new plugin to be fully available — and they can move on to the next lesson after restarting."
+agentInstructions: |
+  Cover these four topics:
+
+  1. What plugins are: JavaScript or TypeScript modules that extend
+     OpenCode by hooking into events, adding custom tools, or integrating
+     external services. They go beyond MCP servers (covered in the Tools
+     lesson) by letting you modify OpenCode's behavior itself rather than
+     just exposing external tools. Reference the Tools lesson so the
+     student sees the progression.
+
+  2. Where plugins live: two scopes: project-level in .opencode/plugins/
+     and global in ~/.config/opencode/plugins/. Can also install npm
+     packages via the plugin array in opencode.json. Dependencies go in a
+     package.json in the same config directory and OpenCode runs
+     bun install automatically at startup.
+
+  3. What plugins can do: subscribe to lifecycle events like session.idle
+     or tool.execute.before. Add custom tools using the tool() helper from
+     @opencode-ai/plugin with Zod schemas for arguments. Inject
+     environment variables. Modify tool behavior with before/after hooks.
+     Plugins can also ship companion skills that inject workflow guidance
+     into the agent prompt.
+
+  4. Installing a real plugin: walk through installing the Replicate
+     plugin as a hands-on example. First get a Replicate API token from
+     replicate.com/account/api-tokens, add
+     `export REPLICATE_API_TOKEN=r8_your_token_here` to their shell
+     profile (.bashrc or .zshrc), then run the quick-install script with
+     `curl -sSL https://raw.githubusercontent.com/lucataco/replicate-opencode-plugin/main/install.sh | bash`
+     from the project root, which downloads the plugin, a companion skill,
+     and a package.json into the .opencode/ directory. After restarting
+     OpenCode, verify by asking "What is my Replicate username?" and
+     confirming the agent calls replicate_whoami and returns account info.
+
+  After teaching and quizzing, verify completion by reading
+  .opencode/plugins/replicate.ts and confirming it exists.
+
+  After marking the lesson complete, do NOT suggest moving on to the next
+  lesson. Instead, tell the student: plugins are loaded at startup, so
+  they need to quit OpenCode Desktop and reopen it for the new plugin to
+  be fully available, and they can move on to the next lesson after
+  restarting.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/lessons/11-agents.mdx
+++ b/src/content/lessons/11-agents.mdx
@@ -4,7 +4,33 @@ slug: agents
 description: "Use Plan and Build agents to think before you act."
 order: 11
 quiz: true
-agentInstructions: "Cover these four topics: (1) what an agent means in OpenCode specifically — a specialized assistant configured for a particular task or workflow, distinct from the broader industry use of the word, (2) the Plan agent — conversational and read-only; it can read files and discuss the project but won't make any changes; the student already set \"default_agent\": \"plan\" in the Configuration lesson so every new session starts here — but note that Plan mode is not a hard sandbox and the agent may still occasionally run commands or make API calls that have side effects, (3) the Build agent — the implementation agent with full access to read, write, and run things; switch to this when you know what you want to do, (4) the recommended workflow — since Plan is already the default, the student is already starting safe; the key skill is knowing when to switch to Build and being deliberate about it, especially for complex or unfamiliar tasks. After teaching and quizzing, verify completion by asking the student to describe when they'd use Plan vs. Build and confirm they understand that Plan is read-only by default but not a guaranteed sandbox, and that Build can make changes."
+agentInstructions: |
+  Cover these four topics:
+
+  1. What an agent means in OpenCode specifically: a specialized assistant
+     configured for a particular task or workflow, distinct from the
+     broader industry use of the word.
+
+  2. The Plan agent: conversational and read-only. It can read files and
+     discuss the project but won't make any changes. The student already
+     set "default_agent": "plan" in the Configuration lesson so every new
+     session starts here, but note that Plan mode is not a hard sandbox
+     and the agent may still occasionally run commands or make API calls
+     that have side effects.
+
+  3. The Build agent: the implementation agent with full access to read,
+     write, and run things. Switch to this when you know what you want
+     to do.
+
+  4. The recommended workflow: since Plan is already the default, the
+     student is already starting safe. The key skill is knowing when to
+     switch to Build and being deliberate about it, especially for complex
+     or unfamiliar tasks.
+
+  After teaching and quizzing, verify completion by asking the student to
+  describe when they'd use Plan vs. Build and confirm they understand that
+  Plan is read-only by default but not a guaranteed sandbox, and that
+  Build can make changes.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/lessons/12-sessions.mdx
+++ b/src/content/lessons/12-sessions.mdx
@@ -4,7 +4,31 @@ slug: sessions
 description: "Manage and resume conversations with Sessions."
 order: 12
 quiz: true
-agentInstructions: "Cover these four topics: (1) what a session is — an individual conversation with OpenCode; each session has its own history and context; a single project can have many sessions, (2) starting a new session — type /new in the prompt (works in both Desktop and TUI) or use the New Session button in the Desktop left sidebar, (3) sessions persist — conversation history is saved to disk, so you can resume any previous session even after quitting and restarting OpenCode, (4) sharing — /share generates a public link at opncd.ai/s/<id> that anyone with the link can view; /unshare removes it; three sharing modes: manual (default, share on demand), auto (every session shared automatically), disabled (sharing turned off entirely). After teaching and quizzing, run 'opencode session list' yourself to get all sessions, pick one that looks interesting, run 'opencode export <sessionID>' on it, and give the student a brief summary of what was being worked on in that session. Then mark the lesson complete."
+agentInstructions: |
+  Cover these four topics:
+
+  1. What a session is: an individual conversation with OpenCode. Each
+     session has its own history and context. A single project can have
+     many sessions.
+
+  2. Starting a new session: type /new in the prompt (works in both
+     Desktop and TUI) or use the New Session button in the Desktop left
+     sidebar.
+
+  3. Sessions persist: conversation history is saved to disk, so you can
+     resume any previous session even after quitting and restarting
+     OpenCode.
+
+  4. Sharing: /share generates a public link at opncd.ai/s/<id> that
+     anyone with the link can view. /unshare removes it. Three sharing
+     modes: manual (default, share on demand), auto (every session shared
+     automatically), disabled (sharing turned off entirely).
+
+  After teaching and quizzing, run `opencode session list` yourself to get
+  all sessions, pick one that looks interesting, run
+  `opencode export <sessionID>` on it, and give the student a brief
+  summary of what was being worked on in that session. Then mark the
+  lesson complete.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/lessons/13-images.mdx
+++ b/src/content/lessons/13-images.mdx
@@ -4,7 +4,34 @@ slug: images
 description: "Share images and screenshots with OpenCode."
 order: 13
 quiz: true
-agentInstructions: "Cover these four topics: (1) what vision capability is — some models can interpret images pasted into the conversation; they can describe photos, extract text from screenshots, and read UI details including layout, spacing, typography, and color, (2) how to add images — drag and drop an image into the OpenCode window, or paste with Cmd+V (Mac) or Ctrl+V (Windows/Linux); images are sent as part of the conversation just like text, (3) which models support vision — all Claude models (Haiku, Sonnet, Opus), all GPT-4 and GPT-5 family models, and Gemini models all have confirmed vision support; Kimi K2.5 via OpenCode Go is the most affordable confirmed vision model; the free Zen models (Big Pickle, MiMo, Nemotron, MiniMax Free) do not have confirmed vision support — if a model doesn't acknowledge your image, switch to a vision-capable model, (4) what vision is useful for — pasting a screenshot of an inspiring UI to replicate, pasting a screenshot of a bug to help diagnose it, pasting a design mockup to implement; the model can interpret colors, spacing, typography, and content from images. After teaching and quizzing, verify completion by confirming the student has pasted or attached an image and received a response that references its contents."
+agentInstructions: |
+  Cover these four topics:
+
+  1. What vision capability is: some models can interpret images pasted
+     into the conversation. They can describe photos, extract text from
+     screenshots, and read UI details including layout, spacing,
+     typography, and color.
+
+  2. How to add images: drag and drop an image into the OpenCode window,
+     or paste with Cmd+V (Mac) or Ctrl+V (Windows/Linux). Images are sent
+     as part of the conversation just like text.
+
+  3. Which models support vision: all Claude models (Haiku, Sonnet, Opus),
+     all GPT-4 and GPT-5 family models, and Gemini models all have
+     confirmed vision support. Kimi K2.5 via OpenCode Go is the most
+     affordable confirmed vision model. The free Zen models (Big Pickle,
+     MiMo, Nemotron, MiniMax Free) do not have confirmed vision support.
+     If a model doesn't acknowledge your image, switch to a
+     vision-capable model.
+
+  4. What vision is useful for: pasting a screenshot of an inspiring UI to
+     replicate, pasting a screenshot of a bug to help diagnose it, pasting
+     a design mockup to implement. The model can interpret colors,
+     spacing, typography, and content from images.
+
+  After teaching and quizzing, verify completion by confirming the student
+  has pasted or attached an image and received a response that references
+  its contents.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'

--- a/src/content/lessons/14-workspaces.mdx
+++ b/src/content/lessons/14-workspaces.mdx
@@ -4,7 +4,32 @@ slug: workspaces
 description: "Run multiple parallel tasks on the same project without file conflicts."
 order: 14
 quiz: true
-agentInstructions: "Cover these four topics: (1) what workspaces are — isolated copies of project files on their own Git branch, letting you work on multiple tasks in parallel without file conflicts; this is a Desktop-only feature that requires the project to be a Git repository, (2) the problem they solve — running multiple sessions on the same project simultaneously risks one session overwriting another's changes; workspaces prevent this by giving each task its own complete copy of the project files, (3) how to create one — right-click the project in the OpenCode Desktop left sidebar, select 'Enable Workspaces', then click 'New Workspace' to create an isolated copy; each workspace gets an auto-generated name and its own branch, (4) what happens under the hood — each workspace creates a branch named opencode/<name> and checks it out to a separate directory on disk; when the work is done, the branch can be merged back into the main branch via Git like any other branch. After teaching and quizzing, verify completion by confirming the student can describe what workspaces are for and how to create one. No file-system check is needed."
+agentInstructions: |
+  Cover these four topics:
+
+  1. What workspaces are: isolated copies of project files on their own
+     Git branch, letting you work on multiple tasks in parallel without
+     file conflicts. This is a Desktop-only feature that requires the
+     project to be a Git repository.
+
+  2. The problem they solve: running multiple sessions on the same project
+     simultaneously risks one session overwriting another's changes.
+     Workspaces prevent this by giving each task its own complete copy of
+     the project files.
+
+  3. How to create one: right-click the project in the OpenCode Desktop
+     left sidebar, select "Enable Workspaces", then click "New Workspace"
+     to create an isolated copy. Each workspace gets an auto-generated
+     name and its own branch.
+
+  4. What happens under the hood: each workspace creates a branch named
+     opencode/<name> and checks it out to a separate directory on disk.
+     When the work is done, the branch can be merged back into the main
+     branch via Git like any other branch.
+
+  After teaching and quizzing, verify completion by confirming the student
+  can describe what workspaces are for and how to create one. No
+  file-system check is needed.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'


### PR DESCRIPTION
## Summary

This PR reformats all `agentInstructions` in lesson and exercise MDX frontmatter from single-line quoted strings to YAML literal block scalars (`|`). No content or code changes, just formatting for readability.

- Converts inline `(1)`, `(2)` numbering to proper numbered lists
- Adds paragraph breaks between logical sections (topics, verification steps, post-completion instructions)
- Wraps lines at ~76 characters so diffs are line-level instead of whole-string
- Updates AGENTS.md with block scalar authoring guidance
- 20 MDX files reformatted (13 lessons, 7 exercises); `02-interview.mdx` already used `|`

Before:
```yaml
agentInstructions: "Cover these four topics: (1) what AGENTS.md does — it gives OpenCode standing instructions that apply to every session, (2) the difference between..."
```

After:
```yaml
agentInstructions: |
  Cover these four topics:

  1. What AGENTS.md does: it gives OpenCode standing instructions that
     apply to every session.

  2. The difference between...
```