### PR TITLE
feat: add 'Achieve inbox zero' exercise

### DIFF
--- a/src/content/exercises/08-achieve-inbox-zero.mdx
+++ b/src/content/exercises/08-achieve-inbox-zero.mdx
@@ -1,0 +1,53 @@
+---
+title: "Achieve inbox zero"
+slug: achieve-inbox-zero
+description: "Triage your email inbox, batch-process messages, and send emails using Gmail."
+order: 8
+agentInstructions: "Guide the student through connecting OpenCode to their Gmail account and using it to triage, batch-process, and send email. Adapt depth to their profile. Steps: (1) Check if gcloud is installed by running `gcloud --version`. If not, help them install it — use `brew install google-cloud-sdk` on macOS, or direct them to https://cloud.google.com/sdk for other platforms. (2) Check if gws is installed by running `gws --version`. If not, install via `brew install googleworkspace-cli`. Note: this conflicts with the `gws` Homebrew formula (a different tool for git workspaces). If the student already has that installed, they will need to `brew unlink gws` first. (3) Run `gws auth setup --login` to create a GCP project, configure the OAuth consent screen, create an OAuth client, and authenticate with Gmail scope in one step. A browser window opens for Google OAuth but no manual GCP console work is needed. Verify auth with `gws auth status`. (4) Help the student create a personalized gws-gmail skill at ~/.config/opencode/skills/gws-gmail/SKILL.md. The skill should include their Gmail address, their GCP project ID (shown in `gws auth status` output), and a reference for the key gws helper commands: +triage (inbox summary), +read (read a message), +send (compose), +reply (reply to a message), +forward (forward a message). Include a send safety rule in the skill: all outgoing commands (+send, +reply, +reply-all, +forward) MUST use --draft unless the user explicitly says to send. Explain that this skill teaches the agent how to manage their specific Gmail account. (5) Tell the student to quit and reopen OpenCode Desktop so the new skill loads. (6) After restart, triage the inbox: run `gws gmail +triage --max 30` to pull a batch of unread messages. Summarize and categorize each message for the student: needs a reply, FYI only, can archive, or junk. Present this as an organized table or list so the student can see everything at a glance and make decisions quickly. (7) Batch-process messages based on the student's decisions. Archive FYI and noise messages using `gws gmail users messages modify --params '{\"id\":\"MSG_ID\"}' --json '{\"removeLabelIds\":[\"INBOX\"]}'`. Mark newsletters and low-priority messages as read with `'{\"removeLabelIds\":[\"UNREAD\"]}'`. Process multiple messages per batch without requiring individual confirmation for each — ask once for a category, then execute. The goal is inbox zero or close to it. (8) Demonstrate Gmail search and filtering with query syntax: `from:`, `after:`, `before:`, `subject:`, `has:attachment`, `filename:pdf`, `label:`, `is:unread`. Show how to combine queries. Help the student find and process older threads, messages from a specific sender, or messages with attachments. Use `gws gmail +triage --query '<query>'` for filtered views. (9) Help the student compose and send an email. Always draft first with `gws gmail +send --to <recipient> --subject '<subject>' --body '<body>' --draft`. Show what was drafted (recipient, subject, body summary) and wait for explicit confirmation before sending without --draft. If the student wants to reply to a message found during triage, use `gws gmail +reply --message-id <MSG_ID> --body '<body>' --draft` instead. (10) Verify completion by confirming the student has (a) triaged and batch-processed at least several messages from their inbox and (b) successfully sent or replied to at least one email via gws."
+---
+
+import AgentPrompt from '../../components/AgentPrompt.astro'
+
+Email is one of the most time-consuming daily tasks. In this exercise, you'll connect OpenCode to your Gmail account and use it to triage your inbox in bulk, batch-process messages, and compose and send email, all without opening Gmail in a browser. The agent reads, categorizes, and acts on your messages so you can get to inbox zero faster.
+
+<AgentPrompt title="Achieve inbox zero" prompt='Let&#39;s work on the "Achieve inbox zero" exercise together!' />
+
+## Prerequisites
+
+You'll need a [Gmail](https://gmail.com) account and two CLI tools:
+
+**[Google Cloud SDK](https://cloud.google.com/sdk)** (`gcloud`) provides the authentication infrastructure. Install it with:
+
+```
+brew install google-cloud-sdk
+```
+
+On Windows or Linux, download from [cloud.google.com/sdk](https://cloud.google.com/sdk).
+
+**[Google Workspace CLI](https://github.com/googleworkspace/cli)** (`gws`) is the tool that actually talks to Gmail. Install it with:
+
+```
+brew install googleworkspace-cli
+```
+
+Once both are installed, run `gws auth setup --login` to create a GCP project, configure OAuth, and authenticate with your Gmail account in one step. A browser window opens for Google sign-in, but you don't need to touch the Google Cloud console manually.
+
+## What you'll do
+
+- **Triage** your unread inbox in one pass — the agent reads all your messages, categorizes them (needs reply, FYI, archive, junk), and presents a summary so you can make decisions at a glance
+- **Batch-process** messages — archive noise, mark newsletters as read, and clear out low-priority threads in bulk instead of one at a time
+- **Search** your mailbox using Gmail query syntax to find messages by sender, date, subject, or attachments
+- **Compose and send** an email with a draft-first safety pattern — always review before sending
+- **Create a skill** that teaches OpenCode how to manage your specific Gmail account
+
+## Drafts first
+
+Every outgoing email goes through a draft step. The agent composes the message, shows you the recipient, subject, and body, and waits for your explicit go-ahead before sending. There is no undo for sent email, so the draft step is your safety net.
+
+## Beyond Gmail
+
+The `gws` CLI covers more than just email. It supports Drive, Calendar, Sheets, Docs, Chat, Admin, and other Google Workspace services. Once you're comfortable with the Gmail workflow, you can expand your skill to cover other services by authenticating with additional scopes:
+
+```
+gws auth login -s gmail,drive,calendar
+```


### PR DESCRIPTION
This PR adds a new exercise that teaches students to manage their Gmail inbox using OpenCode and the `gws` (Google Workspace CLI) tool.

The exercise covers:

- Installing `gcloud` and `gws`, authenticating with `gws auth setup --login` (no GCP console needed)
- Creating a personalized `gws-gmail` skill from scratch
- Batch inbox triage: the agent reads all unread messages, categorizes them, and presents a summary
- Batch processing: archive, mark-read, and clear messages in bulk
- Gmail search query syntax for filtering by sender, date, attachments, etc.
- Composing and sending email with a draft-first safety pattern
- A note on expanding to other Google Workspace services (Drive, Calendar, Sheets)

The exercise is framed around achieving inbox zero, where the agent helps the student systematically process their entire inbox rather than handling messages one at a time.