### PR TITLE
feat: add fixed GitHub Octocat icon in top-right corner on desktop

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -542,6 +542,18 @@ const currentPath = Astro.url.pathname;
     <script defer src="https://cloud.umami.is/script.js" data-website-id="a3d79131-e6af-4376-b614-b7bd60af46f8"></script>
   </head>
   <body class="min-h-screen">
+    <!-- Fixed GitHub corner icon (desktop only) -->
+    <a
+      href="https://github.com/opencodeschool/opencode.school"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="hidden lg:block fixed top-5 right-5 z-40 text-gray-300 hover:text-gray-500 dark:text-stone-700 dark:hover:text-stone-500 transition-colors"
+      aria-label="Open source on GitHub"
+    >
+      <svg class="w-7 h-7" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.342-3.369-1.342-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+      </svg>
+    </a>
     <div class="lg:flex">
       <!-- Mobile header -->
       <header class="lg:hidden flex items-center justify-between p-4 border-b border-gray-200 dark:border-stone-800">

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -547,7 +547,7 @@ const currentPath = Astro.url.pathname;
       href="https://github.com/opencodeschool/opencode.school"
       target="_blank"
       rel="noopener noreferrer"
-      class="hidden lg:block fixed top-5 right-5 z-40 text-gray-300 hover:text-gray-500 dark:text-stone-700 dark:hover:text-stone-500 transition-colors"
+      class="hidden lg:block fixed top-5 right-5 z-40 text-gray-400 hover:text-gray-600 dark:text-stone-600 dark:hover:text-stone-400 transition-colors"
       aria-label="Open source on GitHub"
     >
       <svg class="w-7 h-7" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">


### PR DESCRIPTION
This PR adds a fixed-position GitHub Octocat icon in the top-right corner of the viewport so visitors can more easily discover that the project is open source.

- Uses `fixed top-5 right-5` positioning so it stays visible as users scroll
- Hidden on mobile (`hidden lg:block`) to avoid overlapping the hamburger menu
- Faint colors in both light mode (`text-gray-300`) and dark mode (`dark:text-stone-700`) with brighter hover states
- Links to the repo at `github.com/opencodeschool/opencode.school`
- Reuses the same Octocat SVG already in the sidebar icon row

<img width="703" height="668" alt="Screen Shot 2026-04-15 at 10 42 00@2x" src="https://github.com/user-attachments/assets/b4e9cb24-c2ed-4170-9571-96e6990ea678" />