### PR TITLE
feat: add 'Use an AI gateway' exercise

### DIFF
--- a/src/content/exercises/08-use-an-ai-gateway.mdx
+++ b/src/content/exercises/08-use-an-ai-gateway.mdx
@@ -1,0 +1,119 @@
+---
+title: "Use an AI gateway"
+slug: use-an-ai-gateway
+description: "Route AI requests through Cloudflare's AI Gateway with Unified Billing."
+order: 8
+agentInstructions: |
+  Guide the student through setting up Cloudflare AI Gateway for OpenCode.
+  Adapt depth and pace to their profile.
+
+  Steps:
+
+  1. Check prerequisites: Node.js installed (`node --version`), Cloudflare
+     account authenticated (`npx wrangler whoami`). If not authenticated,
+     run `npx wrangler login`. If they don't have a Cloudflare account,
+     help them sign up at https://dash.cloudflare.com/sign-up.
+
+  2. Create an AI Gateway in the Cloudflare dashboard: navigate to AI >
+     AI Gateway > Create gateway. Name it "opencode". Enable
+     authentication and logging.
+
+  3. Enable Unified Billing: go to the gateway's Settings tab, enable
+     "Unified Billing", and load at least $5 in credits. Explain that
+     Unified Billing lets the gateway pay providers (Anthropic, OpenAI,
+     etc.) on their behalf — no separate API keys needed for each
+     provider.
+
+  4. Create a gateway authentication token: go to the gateway's
+     Authentication tab and create a new token. Copy the token (it starts
+     with cfut_). This token is different from a regular Cloudflare API
+     token — it authenticates requests to the gateway specifically.
+
+  5. Set environment variables. The student needs CLOUDFLARE_ACCOUNT_ID
+     and CLOUDFLARE_GATEWAY_ID ("opencode") in their shell profile
+     (~/.zshrc or ~/.bashrc). They can find their account ID by running
+     `npx wrangler whoami` or in the Cloudflare dashboard URL.
+
+  6. Store the gateway token in OpenCode: in OpenCode Desktop, click the
+     model name below the prompt, then click the settings button, and
+     select "Cloudflare AI Gateway". In the terminal app, run `/connect`
+     and select "Cloudflare AI Gateway". Enter the cfut_ token when
+     prompted.
+
+     Important: if CLOUDFLARE_API_TOKEN is already set in the student's
+     environment (e.g. for wrangler or other Cloudflare tools), OpenCode
+     will use that value instead of the token from /connect. The student
+     should either unset CLOUDFLARE_API_TOKEN, rename it (e.g. to
+     CLOUDFLARE_API_TOKEN_GENERAL), or set it to the cfut_ gateway token.
+     Wrangler will continue to work via its OAuth session from
+     `wrangler login`.
+
+  7. Add the cloudflare-ai-gateway provider to the student's
+     opencode.jsonc config with at least two models from different
+     providers. Example:
+
+     "provider": {
+       "cloudflare-ai-gateway": {
+         "models": {
+           "anthropic/claude-sonnet-4-20250514": {
+             "name": "Claude Sonnet 4 (CF Gateway)"
+           },
+           "openai/gpt-4.1": {
+             "name": "GPT-4.1 (CF Gateway)"
+           }
+         }
+       }
+     }
+
+     The student should restart OpenCode Desktop after saving the config.
+
+  8. Test: switch to a gateway model with /models (or click the model
+     name), send a test message, and confirm a response comes back. Then
+     check the gateway's Logs tab in the Cloudflare dashboard to verify
+     the request was logged.
+
+  Verify completion by confirming the student can chat through at least
+  two different provider models via the gateway and see the requests
+  logged in the Cloudflare dashboard.
+---
+
+import AgentPrompt from '../../components/AgentPrompt.astro'
+
+When you use an AI model in OpenCode, your request goes directly to the model provider: Anthropic, OpenAI, Google, or whoever hosts the model. That means a separate account, a separate API key, and a separate bill for each provider. An AI gateway sits between OpenCode and the providers, giving you a single point of control: one bill, one set of logs, one place to manage access.
+
+In this exercise, you'll set up [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) and connect it to OpenCode. With [Unified Billing](https://developers.cloudflare.com/ai-gateway/features/unified-billing/), you load credits into your Cloudflare account and use models from Anthropic, OpenAI, and other providers without needing their API keys. Cloudflare handles the provider payments.
+
+<AgentPrompt title="Use an AI gateway" prompt='Let&#39;s work on the "Use an AI gateway" exercise together!' />
+
+## Why use a gateway?
+
+Without a gateway, every provider is a separate relationship: sign up, get an API key, manage billing, check usage. With a gateway:
+
+- **One bill** — load credits once, use models from any supported provider
+- **Logging** — every request and response is logged in one place, useful for debugging and understanding usage
+- **Provider switching** — try different models without creating new accounts or managing new API keys
+- **Caching** — repeated identical requests can be served from cache, saving money and reducing latency
+
+AI gateways are a common pattern. OpenCode's own [Zen](https://opencode.ai/docs/zen/) and [Go](https://opencode.ai/docs/go/) plans work the same way — they're gateways that proxy your requests to multiple providers behind a single API key. In this exercise, you'll set up your own gateway with Cloudflare, giving you direct control over which providers you use, how much you spend, and what gets logged.
+
+## Prerequisites
+
+You'll need a free [Cloudflare account](https://dash.cloudflare.com/sign-up) and [Node.js](https://nodejs.org) installed (for the `wrangler` CLI). If you completed the [Build a website](/exercises/build-a-website) exercise, you already have both.
+
+You'll also load at least $5 in credits into the gateway for Unified Billing. This is real money, but $5 goes a long way: a typical Claude Sonnet conversation costs a few cents.
+
+## What you'll do
+
+- **Create a gateway** in the Cloudflare dashboard with authentication and logging enabled
+- **Enable Unified Billing** so Cloudflare handles payments to Anthropic, OpenAI, and other providers on your behalf
+- **Store the gateway token** in OpenCode so it can authenticate with the gateway
+- **Add models** from at least two different providers to your OpenCode config (e.g. Claude Sonnet and GPT-4.1)
+- **Test it** by chatting through the gateway and checking the logs in the Cloudflare dashboard
+
+## A note on environment variables
+
+The gateway uses a token (starting with `cfut_`) that's different from a regular Cloudflare API token. If you already have `CLOUDFLARE_API_TOKEN` set in your shell for wrangler or other Cloudflare tools, OpenCode will use that instead of the gateway token. The agent will help you sort this out during setup. Wrangler itself doesn't need that environment variable if you've run `wrangler login` — it has its own OAuth session.
+
+## Automate the dashboard setup
+
+The gateway setup involves several clicks in the Cloudflare dashboard: creating the gateway, enabling authentication, loading credits, generating a token. If you completed the [Drive a browser](/exercises/drive-a-browser) exercise and have Chrome DevTools MCP configured, you can let the agent do the clicking for you. Describe what you want in Plan Mode and let it drive the dashboard.

--- a/src/content/lessons/06-models.mdx
+++ b/src/content/lessons/06-models.mdx
@@ -23,7 +23,9 @@ agentInstructions: |
   4. Cloudflare as a model provider: AI Gateway is a proxy that routes
      requests to providers like OpenAI and Anthropic through a single
      Cloudflare bill via Unified Billing, so you don't need separate API
-     keys for each provider. Workers AI is a separate option that runs
+     keys for each provider. The "Use an AI gateway" exercise covers the
+     full setup — the student will get to it after finishing the lessons.
+     Workers AI is a separate option that runs
      open-source models directly on Cloudflare's network but is more
      limited since it only hosts certain models. Both are useful if you
      already have a Cloudflare account.
@@ -96,7 +98,7 @@ If you already have a Cloudflare account, you can use it as a model provider in 
 
 Cloudflare also offers **Workers AI**, which runs open-source models directly on Cloudflare's network. It's more limited than AI Gateway (only the models Cloudflare hosts), but it's there if you want it.
 
-To set up either provider, see the [Cloudflare AI Gateway](https://opencode.ai/docs/providers/#cloudflare-ai-gateway) and [Cloudflare Workers AI](https://opencode.ai/docs/providers/#cloudflare-workers-ai) sections of the providers documentation.
+To set up either provider, see the [Cloudflare AI Gateway](https://opencode.ai/docs/providers/#cloudflare-ai-gateway) and [Cloudflare Workers AI](https://opencode.ai/docs/providers/#cloudflare-workers-ai) sections of the providers documentation. For a hands-on walkthrough, the [Use an AI gateway](/exercises/use-an-ai-gateway) exercise covers the full setup once you've finished the lessons.
 
 ## Context and context windows
 


### PR DESCRIPTION
This PR adds exercise 08, "Use an AI gateway," which walks students through setting up Cloudflare AI Gateway with Unified Billing for OpenCode.

## New exercise covers

- Creating an AI Gateway in the Cloudflare dashboard with authentication and logging
- Enabling Unified Billing so Cloudflare handles provider payments
- Storing the gateway token in OpenCode (including the `CLOUDFLARE_API_TOKEN` env var conflict gotcha)
- Adding models from multiple providers (Anthropic, OpenAI) to `opencode.jsonc`
- Testing by chatting through the gateway and checking logs
- Optional: automating dashboard setup with Chrome DevTools MCP from exercise 05

## Models lesson update

Added a link to the new exercise in both the `agentInstructions` and body of the Models lesson (Cloudflare section), framed as "you'll get to this after finishing the lessons."