### PR TITLE
feat: add /contributing page and invite students to share ideas

### DIFF
--- a/src/content/exercises/07-use-git-and-github.mdx
+++ b/src/content/exercises/07-use-git-and-github.mdx
@@ -1,13 +1,14 @@
 ---
 title: "Use Git and GitHub"
 slug: use-git-and-github
-description: "Track and manage file changes with Git and GitHub Desktop."
+description: "Track changes with Git and GitHub, and make your first open-source contribution."
 order: 7
 agentInstructions: |
-  Guide the student through using Git and GitHub to track project changes.
-  Adapt depth to their profile.
+  Guide the student through using Git and GitHub to track project changes,
+  and ramp them up to making a real contribution to OpenCode School. Adapt
+  depth to their profile.
 
-  Steps:
+  Core steps (always do these):
 
   1. Check if Git is installed by running `git --version`. If not,
      recommend installing GitHub Desktop from https://desktop.github.com/,
@@ -48,11 +49,62 @@ agentInstructions: |
      disappears. Explain this as a way to try things without affecting
      working code.
 
-  After the core steps, suggest next steps: writing a `.gitignore` file,
-  making a pull request, or exploring the repository on github.com.
+  After the core steps, explain that the most valuable thing anyone can
+  do as an open-source contributor is share ideas and report issues on
+  GitHub. This does not require any of the Git setup you just walked
+  through — just a GitHub account. Point them at
+  {origin}/contributing for the full picture.
 
-  Verify completion by confirming the student has a local Git repository
-  with at least two commits and has pushed it to GitHub.
+  Then offer two paths for completing this exercise:
+
+  Path A (short): keep going with their own repository. Make sure they
+  have a local repo with at least two commits pushed to GitHub. If they
+  prefer this path, verify their remote repo exists, then mark the
+  exercise complete.
+
+  Path B (contribution): make their first real contribution to
+  OpenCode School. Walk them through:
+
+  1. Fork `opencodeschool/opencode.school` on GitHub, via
+     `gh repo fork opencodeschool/opencode.school --clone` or GitHub
+     Desktop's File > Clone Repository > URL flow with the student
+     entering their fork URL after forking on github.com.
+
+  2. Clone the fork locally (or confirm `gh repo fork` already did this)
+     and change into the project directory.
+
+  3. Create a new branch with a descriptive name,
+     e.g. `git checkout -b fix-typo-in-lesson`.
+
+  4. Help them find a small, real improvement to make. Good options:
+     - Fix a typo or unclear sentence in a lesson or page they've
+       already read.
+     - Pick an open issue they'd like to take on. Browse
+       https://github.com/opencodeschool/opencode.school/issues and
+       search before choosing, so they don't duplicate existing work.
+     - Make a small clarification to the glossary, tips, or
+       troubleshooting pages.
+     Encourage them to pick something small for their first PR.
+
+  5. Make the change. Commit it with a clear message.
+
+  6. Push the branch to their fork.
+
+  7. Open a pull request against `opencodeschool/opencode.school:main`
+     via `gh pr create --web` or GitHub Desktop's "Create Pull Request"
+     button. Help them write a concise title and body that explains what
+     changed and why.
+
+  8. Have the student share the PR URL with you. Confirm the URL exists
+     and points at a PR in the opencodeschool/opencode.school repo.
+
+  Mark the exercise complete if either path reaches its end state: Path A
+  requires at least two commits pushed to a GitHub repo; Path B requires
+  an open PR against opencodeschool/opencode.school.
+
+  Whichever path they choose, close with a reminder: filing GitHub issues
+  about anything confusing, broken, or missing is always welcome and
+  never requires forking or sending a PR. See {origin}/contributing.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'
@@ -61,7 +113,7 @@ When OpenCode edits files in your project, you want to know exactly what changed
 
 But you don't need to be a developer or share your work with anyone to benefit from Git. Even if you only use it locally, Git gives you a complete history of your project. Every commit is a snapshot you can return to. If OpenCode makes a change you don't like, you can revert it. You never have to worry about accidentally losing or overwriting work.
 
-[GitHub](https://github.com) is a platform for hosting Git repositories in the cloud. It makes it easy to back up your projects, share them publicly, and collaborate with others. Together, Git and GitHub form the standard toolkit for managing code — and they work just as well for any project with files you want to track.
+[GitHub](https://github.com) is a platform for hosting Git repositories in the cloud. It makes it easy to back up your projects, share them publicly, and collaborate with others. Together, Git and GitHub form the standard toolkit for managing code, and they work just as well for any project with files you want to track.
 
 <AgentPrompt title="Use Git and GitHub" prompt='Let&#39;s work on the "Use Git and GitHub" exercise together!' />
 
@@ -69,14 +121,22 @@ But you don't need to be a developer or share your work with anyone to benefit f
 
 The easiest way to get Git running is to install [GitHub Desktop](https://desktop.github.com/). It handles three things at once: installing Git on your machine, creating a GitHub account if you don't have one, and authenticating the Git CLI so commands like `git push` work automatically.
 
-If you already use Git from the command line, you can skip GitHub Desktop entirely — the exercise works either way.
+If you already use Git from the command line, you can skip GitHub Desktop entirely. The exercise works either way.
 
 ## What you'll do
 
-- **Initialize a repository** in a project folder so Git starts tracking changes
-- **Make commits** — save snapshots of your work with a short description of what changed
-- **Review diffs** — use GitHub Desktop or `git diff` to see exactly what OpenCode changed in your files
-- **Push to GitHub** — back up your repository to the cloud, public or private
-- **Create a branch** — try something experimental without affecting your main project
+- Initialize a repository in a project folder so Git starts tracking changes
+- Make commits: save snapshots of your work with a short description of what changed
+- Review diffs: use GitHub Desktop or `git diff` to see exactly what OpenCode changed in your files
+- Push to GitHub: back up your repository to the cloud, public or private
+- Create a branch: try something experimental without affecting your main project
 
 Once the basics are working, you can go further: write a `.gitignore` to keep clutter out of your repository, open a pull request, or explore your project's commit history on github.com.
+
+## Contribute to OpenCode School
+
+Once you're comfortable with commits, branches, and GitHub, you're ready to make your first real open-source contribution. This exercise includes an optional second path where OpenCode walks you through forking the [OpenCode School repository](https://github.com/opencodeschool/opencode.school), making a small improvement, and opening a pull request against it.
+
+You don't have to take this path to finish the exercise. If you'd rather stick with your own repo, that's fine. But if you've ever wanted to contribute to open source, this is a low-stakes way to do it. OpenCode will help you find a small change to make and walk you through every step.
+
+And remember: you don't need any of this to help improve OpenCode School. Filing a GitHub issue about something confusing, broken, or missing is always welcome and doesn't require Git at all. See [Contributing](/contributing) for more.

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -683,6 +683,17 @@ const currentPath = Astro.url.pathname;
             Glossary
           </a>
           <a
+            href="/contributing"
+            class:list={[
+              "block px-3 py-1.5 rounded-md text-sm transition-colors",
+              currentPath === "/contributing" || currentPath === "/contributing/"
+                ? "theme-active-nav font-medium"
+                : "text-gray-600 hover:text-gray-900 hover:bg-gray-50 dark:text-stone-400 dark:hover:text-stone-200 dark:hover:bg-stone-800",
+            ]}
+          >
+            Contributing
+          </a>
+          <a
             href="/troubleshooting"
             class:list={[
               "block px-3 py-1.5 rounded-md text-sm transition-colors",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -28,7 +28,7 @@ import Base from "../layouts/Base.astro";
     is a community project, not an official Anomaly product. The course itself is
     <a href="https://github.com/opencodeschool/opencode.school" target="_blank" rel="noopener noreferrer">open source</a>
     and
-    <a href="https://github.com/opencodeschool/opencode.school" target="_blank" rel="noopener noreferrer">contributions are welcome</a>.
+    <a href="/contributing">contributions are welcome</a>.
   </p>
 
   <!-- Logos section -->

--- a/src/pages/contributing.astro
+++ b/src/pages/contributing.astro
@@ -1,0 +1,133 @@
+---
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export const prerender = true;
+
+import Base from "../layouts/Base.astro";
+
+const issuesBase = "https://github.com/opencodeschool/opencode.school/issues";
+const newIssue = `${issuesBase}/new`;
+
+const bugTitle = encodeURIComponent("Something isn't working or is confusing: ");
+const bugBody = encodeURIComponent(
+  [
+    "What happened:",
+    "",
+    "What I expected:",
+    "",
+    "Where (lesson, exercise, or page):",
+    "",
+  ].join("\n"),
+);
+
+const ideaTitle = encodeURIComponent("Idea: ");
+const ideaBody = encodeURIComponent(
+  [
+    "What would make OpenCode School better:",
+    "",
+    "Why this would help students:",
+    "",
+  ].join("\n"),
+);
+
+const exerciseTitle = encodeURIComponent("Exercise idea: ");
+const exerciseBody = encodeURIComponent(
+  [
+    "What the exercise would teach or let students build:",
+    "",
+    "A prompt or starting point that worked well for me:",
+    "",
+    "Who this would be useful for:",
+    "",
+  ].join("\n"),
+);
+
+const bugUrl = `${newIssue}?title=${bugTitle}&body=${bugBody}`;
+const ideaUrl = `${newIssue}?title=${ideaTitle}&body=${ideaBody}`;
+const exerciseUrl = `${newIssue}?title=${exerciseTitle}&body=${exerciseBody}`;
+---
+
+<Base title="Contributing" description="Share ideas, report issues, and help improve OpenCode School for future students.">
+  <div class="mb-6">
+    <a href="/" class="text-sm text-gray-500 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors">
+      &larr; All lessons
+    </a>
+  </div>
+
+  <header class="mb-8">
+    <h1 class="text-3xl font-bold">Contributing</h1>
+    <p class="text-gray-600 dark:text-stone-400 mt-2">Share ideas and help improve the course for future students.</p>
+  </header>
+
+  <article class="prose dark:prose-invert max-w-none">
+    <p>
+      Your experience shapes this course. If something is confusing, broken, or
+      missing, or if you come up with an idea that would make OpenCode School
+      better, we want to hear about it.
+    </p>
+    <p>
+      The most valuable thing you can do is <strong>tell us about it on GitHub</strong>.
+      You don't need to know Git or how to code. A free GitHub account and a
+      short description is all it takes. If you don't have an account yet, you
+      can create one at
+      <a href="https://github.com/signup" target="_blank" rel="noopener noreferrer">github.com/signup</a>.
+    </p>
+
+    <h2 id="something-isnt-working"><a href="#something-isnt-working" class="heading-anchor">Something isn't working or is confusing</a></h2>
+    <p>
+      Hit a wall? Instructions that didn't match what you saw? A lesson step
+      that didn't work? Let us know what happened, where, and what you expected
+      instead. Even a one-line description is useful.
+    </p>
+    <p>
+      <a href={bugUrl} target="_blank" rel="noopener noreferrer">Report an issue &rarr;</a>
+    </p>
+
+    <h2 id="suggest-an-idea"><a href="#suggest-an-idea" class="heading-anchor">You have an idea for improving the school</a></h2>
+    <p>
+      Wish a lesson explained something differently? Want a new topic covered?
+      Think the site could do something it currently doesn't? Open an issue
+      describing the idea and why it would help.
+    </p>
+    <p>
+      <a href={ideaUrl} target="_blank" rel="noopener noreferrer">Suggest an idea &rarr;</a>
+    </p>
+
+    <h2 id="share-an-exercise"><a href="#share-an-exercise" class="heading-anchor">You came up with a prompt or exercise worth sharing</a></h2>
+    <p>
+      If you discovered a prompt that worked surprisingly well, or built
+      something with OpenCode that other students would find interesting,
+      describe it in an issue. Maintainers can help shape the idea into a new
+      exercise. You don't have to write the exercise yourself.
+    </p>
+    <p>
+      <a href={exerciseUrl} target="_blank" rel="noopener noreferrer">Propose an exercise &rarr;</a>
+    </p>
+
+    <h2 id="let-opencode-help"><a href="#let-opencode-help" class="heading-anchor">Let OpenCode help you file it</a></h2>
+    <p>
+      If you're already in a session with OpenCode and something comes up that
+      you'd like to report, just say so. OpenCode can draft the issue title and
+      body based on the conversation and hand you a prefilled link, so all you
+      have to do is review and click Submit.
+    </p>
+
+    <h2 id="going-further"><a href="#going-further" class="heading-anchor">Going further: submit a pull request</a></h2>
+    <p>
+      Filing an issue is the most valuable thing you can do, and it's where
+      most contributions start. If you want to go further and fix or build the
+      thing yourself, the <a href="/exercises/use-git-and-github">Use Git and GitHub</a>
+      exercise walks through forking this repository, making a change, and
+      opening a pull request.
+    </p>
+    <p>
+      For the full details on the development setup, lesson authoring
+      conventions, and how the site is put together, see
+      <a href="https://github.com/opencodeschool/opencode.school/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING.md</a>
+      and
+      <a href="https://github.com/opencodeschool/opencode.school/blob/main/AGENTS.md" target="_blank" rel="noopener noreferrer">AGENTS.md</a>
+      in the repository.
+    </p>
+  </article>
+</Base>

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -44,7 +44,34 @@ When presenting multiple choice questions, do not label any answer choice as "Re
 
 If the student has a problem with OpenCode itself (bugs, crashes, unexpected behavior in the OpenCode tool), direct them to the official Anomaly OpenCode Discord: https://opencode.ai/discord
 
-If the student has a problem with OpenCode School (lesson content, enrollment, progress tracking, site issues), guide them to report it on GitHub: https://github.com/opencodeschool/opencode.school/issues — Walk them through the process: they will need a GitHub account to post an issue. If they don't have one, help them understand how to create a free account at https://github.com/signup, then guide them in writing a clear issue with a descriptive title, steps to reproduce, and what they expected vs. what happened.
+If the student has a problem with OpenCode School (lesson content, enrollment, progress tracking, site issues), guide them to report it on GitHub: https://github.com/opencodeschool/opencode.school/issues — see the "Inviting contributions" section below for how to offer to help draft the issue.
+
+## Inviting contributions
+
+Every friction point a student hits is a signal that could make the course better for the next student. Your job is to notice those signals and invite the student to share them as a GitHub issue. Filing an issue is the primary contribution we're asking for. A pull request is a bonus, never a requirement.
+
+Watch for these signals during a session:
+
+- Confusion: the student is stuck, says "this doesn't make sense", or struggles to follow a lesson or exercise.
+- Mismatch: instructions don't match what the student sees (UI changed, command failed, wrong output).
+- Wishes: "I wish this did X", "it would be nice if", "why doesn't the course cover Y".
+- Novel ideas: the student discovers a prompt or workflow that worked well and seems worth sharing, or proposes a new exercise.
+- Apparent bugs or stale content: broken links, outdated screenshots, incorrect steps.
+
+When you notice a signal:
+
+1. First, help the student unblock on the immediate problem if there is one.
+2. Then offer once to help them file a GitHub issue so the course can improve for future students. Keep it light — this is an invitation, not a gate. If they decline, drop it for the rest of the session and don't bring it up again.
+3. If they say yes, draft the issue title and body from the conversation context. They have the details fresh in your conversation; don't make them rewrite them.
+4. Construct a prefilled URL so they just click, review, and submit:
+   \`https://github.com/opencodeschool/opencode.school/issues/new?title=<url-encoded-title>&body=<url-encoded-body>\`
+   URL-encode spaces as %20 and newlines as %0A. Include enough detail in the body that a maintainer reading the issue cold can understand what happened, where, and why it matters.
+5. Share the URL with the student and tell them they can edit the prefilled text on GitHub before submitting.
+6. If they don't have a GitHub account, point them at https://github.com/signup and offer to walk them through creating one.
+
+Never pressure the student into submitting a pull request. Filing an issue is the success case. If the student is curious about going further, the "Use Git and GitHub" exercise walks through forking this repository and opening a PR.
+
+For the full framing students see on the site, link to \`${origin}/contributing\`.
 
 Students who have completed the Configuration lesson may have ${origin}/api/instructions/{studentId} in their OpenCode config's "instructions" array. If so, you already know their student ID from the instructions loaded at session start — use it without asking.
 

--- a/src/pages/troubleshooting.astro
+++ b/src/pages/troubleshooting.astro
@@ -76,18 +76,16 @@ import Base from "../layouts/Base.astro";
     <h2 id="reporting-an-issue-with-opencode-school"><a href="#reporting-an-issue-with-opencode-school" class="heading-anchor">Reporting an issue with OpenCode School</a></h2>
     <p>
       If you find a problem with this course — a broken lesson, incorrect
-      content, enrollment issues, or anything else on this site — please report
-      it on GitHub:
+      content, enrollment issues, or anything else on this site — or if you
+      have an idea for making the course better, please share it on GitHub.
+      Bug reports, suggestions, and ideas for new lessons or exercises are all
+      welcome.
     </p>
     <p>
-      <a href="https://github.com/opencodeschool/opencode.school/issues" target="_blank" rel="noopener noreferrer">https://github.com/opencodeschool/opencode.school/issues</a>
-    </p>
-    <p>
-      To post an issue you'll need a free GitHub account. If you don't have one,
-      you can create one at <a href="https://github.com/signup" target="_blank" rel="noopener noreferrer">github.com/signup</a>.
-      When writing your issue, include a descriptive title, the steps that led to
-      the problem, and what you expected to happen vs. what actually happened.
-      The more detail you provide, the easier it is to fix.
+      See the <a href="/contributing">Contributing</a> page for the easiest
+      ways to file an issue, including prefilled templates for bug reports,
+      ideas, and exercise proposals. OpenCode can also help draft the issue
+      for you based on your session.
     </p>
 
     <h2 id="disenroll"><a href="#disenroll" class="heading-anchor">How to reset progress or disenroll</a></h2>


### PR DESCRIPTION
This PR adds a clear path for students to share ideas and report issues as GitHub issues, rather than leaving friction points invisible. The emphasis is on issues, not PRs. Filing an issue is the success case.

Closes #139

Changes:

- New `/contributing` page with three sections (bug, idea, exercise proposal), each with a prefilled GitHub new-issue URL so students can click, review, and submit.
- Sidebar link between Glossary and Troubleshooting.
- `llms.txt` gets an "Inviting contributions" section that tells agents to watch for confusion, mismatches, wishes, novel ideas, and apparent bugs, and to offer once per session to help the student file a GitHub issue with a prefilled URL drafted from conversation context. Agents are explicitly told not to push for a PR.
- `/troubleshooting` and `/about` link to the new page.
- The Use Git and GitHub exercise now has two end-paths in `agentInstructions`: Path A is the original (two commits pushed to the student's own repo), Path B walks through forking `opencodeschool/opencode.school`, finding a small real improvement, and opening a PR. Either path marks the exercise complete.