### PR TITLE
fix: frame code blocks like agent-prompt cards

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,48 +9,6 @@ import { defineConfig } from "astro/config";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeSlug from "rehype-slug";
 
-/**
- * Strip Shiki's per-token colors so code blocks can be styled with the
- * student's chosen theme color via CSS. Tokens are classified using Vesper's
- * foreground palette so the stylesheet can dim comments and emphasize
- * structural tokens without inline styles fighting our rules.
- */
-const themeAwareShikiTransformer = {
-	name: "school:theme-aware-colors",
-	pre(node) {
-		if (node.properties && typeof node.properties.style === "string") {
-			node.properties.style = node.properties.style
-				.split(";")
-				.map((d) => d.trim())
-				.filter((d) => d && !/^(background-color|color)\s*:/i.test(d))
-				.join(";");
-			if (!node.properties.style) delete node.properties.style;
-		}
-	},
-	span(node, _line, _col, _lineEl, token) {
-		const color = (token?.color || "").toLowerCase();
-		const existing = Array.isArray(node.properties?.className)
-			? node.properties.className
-			: [];
-		// Vesper paints comments as #8b8b8b94 (hex + alpha). That prefix is
-		// unique to the comment scope in this theme.
-		if (color.startsWith("#8b8b8b")) existing.push("tok-comment");
-		// #a0a0a0 is Vesper's color for keywords, punctuation, and other
-		// structural tokens. Treat them uniformly as "structure".
-		else if (color === "#a0a0a0") existing.push("tok-structure");
-		node.properties = node.properties || {};
-		if (existing.length > 0) node.properties.className = existing;
-		if (typeof node.properties.style === "string") {
-			node.properties.style = node.properties.style
-				.split(";")
-				.map((d) => d.trim())
-				.filter((d) => d && !/^color\s*:/i.test(d))
-				.join(";");
-			if (!node.properties.style) delete node.properties.style;
-		}
-	},
-};
-
 export default defineConfig({
 	site: "https://opencode.school",
 	output: "server",
@@ -66,7 +24,6 @@ export default defineConfig({
 		],
 		shikiConfig: {
 			theme: "vesper",
-			transformers: [themeAwareShikiTransformer],
 		},
 	},
 	security: {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,48 @@ import { defineConfig } from "astro/config";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeSlug from "rehype-slug";
 
+/**
+ * Strip Shiki's per-token colors so code blocks can be styled with the
+ * student's chosen theme color via CSS. Tokens are classified using Vesper's
+ * foreground palette so the stylesheet can dim comments and emphasize
+ * structural tokens without inline styles fighting our rules.
+ */
+const themeAwareShikiTransformer = {
+	name: "school:theme-aware-colors",
+	pre(node) {
+		if (node.properties && typeof node.properties.style === "string") {
+			node.properties.style = node.properties.style
+				.split(";")
+				.map((d) => d.trim())
+				.filter((d) => d && !/^(background-color|color)\s*:/i.test(d))
+				.join(";");
+			if (!node.properties.style) delete node.properties.style;
+		}
+	},
+	span(node, _line, _col, _lineEl, token) {
+		const color = (token?.color || "").toLowerCase();
+		const existing = Array.isArray(node.properties?.className)
+			? node.properties.className
+			: [];
+		// Vesper paints comments as #8b8b8b94 (hex + alpha). That prefix is
+		// unique to the comment scope in this theme.
+		if (color.startsWith("#8b8b8b")) existing.push("tok-comment");
+		// #a0a0a0 is Vesper's color for keywords, punctuation, and other
+		// structural tokens. Treat them uniformly as "structure".
+		else if (color === "#a0a0a0") existing.push("tok-structure");
+		node.properties = node.properties || {};
+		if (existing.length > 0) node.properties.className = existing;
+		if (typeof node.properties.style === "string") {
+			node.properties.style = node.properties.style
+				.split(";")
+				.map((d) => d.trim())
+				.filter((d) => d && !/^color\s*:/i.test(d))
+				.join(";");
+			if (!node.properties.style) delete node.properties.style;
+		}
+	},
+};
+
 export default defineConfig({
 	site: "https://opencode.school",
 	output: "server",
@@ -24,6 +66,7 @@ export default defineConfig({
 		],
 		shikiConfig: {
 			theme: "vesper",
+			transformers: [themeAwareShikiTransformer],
 		},
 	},
 	security: {

--- a/src/content/exercises/07-use-git-and-github.mdx
+++ b/src/content/exercises/07-use-git-and-github.mdx
@@ -1,13 +1,14 @@
 ---
 title: "Use Git and GitHub"
 slug: use-git-and-github
-description: "Track and manage file changes with Git and GitHub Desktop."
+description: "Track changes with Git and GitHub, and make your first open-source contribution."
 order: 7
 agentInstructions: |
-  Guide the student through using Git and GitHub to track project changes.
-  Adapt depth to their profile.
+  Guide the student through using Git and GitHub to track project changes,
+  and ramp them up to making a real contribution to OpenCode School. Adapt
+  depth to their profile.
 
-  Steps:
+  Core steps (always do these):
 
   1. Check if Git is installed by running `git --version`. If not,
      recommend installing GitHub Desktop from https://desktop.github.com/,
@@ -48,11 +49,62 @@ agentInstructions: |
      disappears. Explain this as a way to try things without affecting
      working code.
 
-  After the core steps, suggest next steps: writing a `.gitignore` file,
-  making a pull request, or exploring the repository on github.com.
+  After the core steps, explain that the most valuable thing anyone can
+  do as an open-source contributor is share ideas and report issues on
+  GitHub. This does not require any of the Git setup you just walked
+  through — just a GitHub account. Point them at
+  {origin}/contributing for the full picture.
 
-  Verify completion by confirming the student has a local Git repository
-  with at least two commits and has pushed it to GitHub.
+  Then offer two paths for completing this exercise:
+
+  Path A (short): keep going with their own repository. Make sure they
+  have a local repo with at least two commits pushed to GitHub. If they
+  prefer this path, verify their remote repo exists, then mark the
+  exercise complete.
+
+  Path B (contribution): make their first real contribution to
+  OpenCode School. Walk them through:
+
+  1. Fork `opencodeschool/opencode.school` on GitHub, via
+     `gh repo fork opencodeschool/opencode.school --clone` or GitHub
+     Desktop's File > Clone Repository > URL flow with the student
+     entering their fork URL after forking on github.com.
+
+  2. Clone the fork locally (or confirm `gh repo fork` already did this)
+     and change into the project directory.
+
+  3. Create a new branch with a descriptive name,
+     e.g. `git checkout -b fix-typo-in-lesson`.
+
+  4. Help them find a small, real improvement to make. Good options:
+     - Fix a typo or unclear sentence in a lesson or page they've
+       already read.
+     - Pick an open issue they'd like to take on. Browse
+       https://github.com/opencodeschool/opencode.school/issues and
+       search before choosing, so they don't duplicate existing work.
+     - Make a small clarification to the glossary, tips, or
+       troubleshooting pages.
+     Encourage them to pick something small for their first PR.
+
+  5. Make the change. Commit it with a clear message.
+
+  6. Push the branch to their fork.
+
+  7. Open a pull request against `opencodeschool/opencode.school:main`
+     via `gh pr create --web` or GitHub Desktop's "Create Pull Request"
+     button. Help them write a concise title and body that explains what
+     changed and why.
+
+  8. Have the student share the PR URL with you. Confirm the URL exists
+     and points at a PR in the opencodeschool/opencode.school repo.
+
+  Mark the exercise complete if either path reaches its end state: Path A
+  requires at least two commits pushed to a GitHub repo; Path B requires
+  an open PR against opencodeschool/opencode.school.
+
+  Whichever path they choose, close with a reminder: filing GitHub issues
+  about anything confusing, broken, or missing is always welcome and
+  never requires forking or sending a PR. See {origin}/contributing.
 ---
 
 import AgentPrompt from '../../components/AgentPrompt.astro'
@@ -61,7 +113,7 @@ When OpenCode edits files in your project, you want to know exactly what changed
 
 But you don't need to be a developer or share your work with anyone to benefit from Git. Even if you only use it locally, Git gives you a complete history of your project. Every commit is a snapshot you can return to. If OpenCode makes a change you don't like, you can revert it. You never have to worry about accidentally losing or overwriting work.
 
-[GitHub](https://github.com) is a platform for hosting Git repositories in the cloud. It makes it easy to back up your projects, share them publicly, and collaborate with others. Together, Git and GitHub form the standard toolkit for managing code — and they work just as well for any project with files you want to track.
+[GitHub](https://github.com) is a platform for hosting Git repositories in the cloud. It makes it easy to back up your projects, share them publicly, and collaborate with others. Together, Git and GitHub form the standard toolkit for managing code, and they work just as well for any project with files you want to track.
 
 <AgentPrompt title="Use Git and GitHub" prompt='Let&#39;s work on the "Use Git and GitHub" exercise together!' />
 
@@ -69,14 +121,22 @@ But you don't need to be a developer or share your work with anyone to benefit f
 
 The easiest way to get Git running is to install [GitHub Desktop](https://desktop.github.com/). It handles three things at once: installing Git on your machine, creating a GitHub account if you don't have one, and authenticating the Git CLI so commands like `git push` work automatically.
 
-If you already use Git from the command line, you can skip GitHub Desktop entirely — the exercise works either way.
+If you already use Git from the command line, you can skip GitHub Desktop entirely. The exercise works either way.
 
 ## What you'll do
 
-- **Initialize a repository** in a project folder so Git starts tracking changes
-- **Make commits** — save snapshots of your work with a short description of what changed
-- **Review diffs** — use GitHub Desktop or `git diff` to see exactly what OpenCode changed in your files
-- **Push to GitHub** — back up your repository to the cloud, public or private
-- **Create a branch** — try something experimental without affecting your main project
+- Initialize a repository in a project folder so Git starts tracking changes
+- Make commits: save snapshots of your work with a short description of what changed
+- Review diffs: use GitHub Desktop or `git diff` to see exactly what OpenCode changed in your files
+- Push to GitHub: back up your repository to the cloud, public or private
+- Create a branch: try something experimental without affecting your main project
 
 Once the basics are working, you can go further: write a `.gitignore` to keep clutter out of your repository, open a pull request, or explore your project's commit history on github.com.
+
+## Contribute to OpenCode School
+
+Once you're comfortable with commits, branches, and GitHub, you're ready to make your first real open-source contribution. This exercise includes an optional second path where OpenCode walks you through forking the [OpenCode School repository](https://github.com/opencodeschool/opencode.school), making a small improvement, and opening a pull request against it.
+
+You don't have to take this path to finish the exercise. If you'd rather stick with your own repo, that's fine. But if you've ever wanted to contribute to open source, this is a low-stakes way to do it. OpenCode will help you find a small change to make and walk you through every step.
+
+And remember: you don't need any of this to help improve OpenCode School. Filing a GitHub issue about something confusing, broken, or missing is always welcome and doesn't require Git at all. See [Contributing](/contributing) for more.

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -683,6 +683,17 @@ const currentPath = Astro.url.pathname;
             Glossary
           </a>
           <a
+            href="/contributing"
+            class:list={[
+              "block px-3 py-1.5 rounded-md text-sm transition-colors",
+              currentPath === "/contributing" || currentPath === "/contributing/"
+                ? "theme-active-nav font-medium"
+                : "text-gray-600 hover:text-gray-900 hover:bg-gray-50 dark:text-stone-400 dark:hover:text-stone-200 dark:hover:bg-stone-800",
+            ]}
+          >
+            Contributing
+          </a>
+          <a
             href="/troubleshooting"
             class:list={[
               "block px-3 py-1.5 rounded-md text-sm transition-colors",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -28,7 +28,7 @@ import Base from "../layouts/Base.astro";
     is a community project, not an official Anomaly product. The course itself is
     <a href="https://github.com/opencodeschool/opencode.school" target="_blank" rel="noopener noreferrer">open source</a>
     and
-    <a href="https://github.com/opencodeschool/opencode.school" target="_blank" rel="noopener noreferrer">contributions are welcome</a>.
+    <a href="/contributing">contributions are welcome</a>.
   </p>
 
   <!-- Logos section -->

--- a/src/pages/contributing.astro
+++ b/src/pages/contributing.astro
@@ -1,0 +1,133 @@
+---
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export const prerender = true;
+
+import Base from "../layouts/Base.astro";
+
+const issuesBase = "https://github.com/opencodeschool/opencode.school/issues";
+const newIssue = `${issuesBase}/new`;
+
+const bugTitle = encodeURIComponent("Something isn't working or is confusing: ");
+const bugBody = encodeURIComponent(
+  [
+    "What happened:",
+    "",
+    "What I expected:",
+    "",
+    "Where (lesson, exercise, or page):",
+    "",
+  ].join("\n"),
+);
+
+const ideaTitle = encodeURIComponent("Idea: ");
+const ideaBody = encodeURIComponent(
+  [
+    "What would make OpenCode School better:",
+    "",
+    "Why this would help students:",
+    "",
+  ].join("\n"),
+);
+
+const exerciseTitle = encodeURIComponent("Exercise idea: ");
+const exerciseBody = encodeURIComponent(
+  [
+    "What the exercise would teach or let students build:",
+    "",
+    "A prompt or starting point that worked well for me:",
+    "",
+    "Who this would be useful for:",
+    "",
+  ].join("\n"),
+);
+
+const bugUrl = `${newIssue}?title=${bugTitle}&body=${bugBody}`;
+const ideaUrl = `${newIssue}?title=${ideaTitle}&body=${ideaBody}`;
+const exerciseUrl = `${newIssue}?title=${exerciseTitle}&body=${exerciseBody}`;
+---
+
+<Base title="Contributing" description="Share ideas, report issues, and help improve OpenCode School for future students.">
+  <div class="mb-6">
+    <a href="/" class="text-sm text-gray-500 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors">
+      &larr; All lessons
+    </a>
+  </div>
+
+  <header class="mb-8">
+    <h1 class="text-3xl font-bold">Contributing</h1>
+    <p class="text-gray-600 dark:text-stone-400 mt-2">Share ideas and help improve the course for future students.</p>
+  </header>
+
+  <article class="prose dark:prose-invert max-w-none">
+    <p>
+      Your experience shapes this course. If something is confusing, broken, or
+      missing, or if you come up with an idea that would make OpenCode School
+      better, we want to hear about it.
+    </p>
+    <p>
+      The most valuable thing you can do is <strong>tell us about it on GitHub</strong>.
+      You don't need to know Git or how to code. A free GitHub account and a
+      short description is all it takes. If you don't have an account yet, you
+      can create one at
+      <a href="https://github.com/signup" target="_blank" rel="noopener noreferrer">github.com/signup</a>.
+    </p>
+
+    <h2 id="something-isnt-working"><a href="#something-isnt-working" class="heading-anchor">Something isn't working or is confusing</a></h2>
+    <p>
+      Hit a wall? Instructions that didn't match what you saw? A lesson step
+      that didn't work? Let us know what happened, where, and what you expected
+      instead. Even a one-line description is useful.
+    </p>
+    <p>
+      <a href={bugUrl} target="_blank" rel="noopener noreferrer">Report an issue &rarr;</a>
+    </p>
+
+    <h2 id="suggest-an-idea"><a href="#suggest-an-idea" class="heading-anchor">You have an idea for improving the school</a></h2>
+    <p>
+      Wish a lesson explained something differently? Want a new topic covered?
+      Think the site could do something it currently doesn't? Open an issue
+      describing the idea and why it would help.
+    </p>
+    <p>
+      <a href={ideaUrl} target="_blank" rel="noopener noreferrer">Suggest an idea &rarr;</a>
+    </p>
+
+    <h2 id="share-an-exercise"><a href="#share-an-exercise" class="heading-anchor">You came up with a prompt or exercise worth sharing</a></h2>
+    <p>
+      If you discovered a prompt that worked surprisingly well, or built
+      something with OpenCode that other students would find interesting,
+      describe it in an issue. Maintainers can help shape the idea into a new
+      exercise. You don't have to write the exercise yourself.
+    </p>
+    <p>
+      <a href={exerciseUrl} target="_blank" rel="noopener noreferrer">Propose an exercise &rarr;</a>
+    </p>
+
+    <h2 id="let-opencode-help"><a href="#let-opencode-help" class="heading-anchor">Let OpenCode help you file it</a></h2>
+    <p>
+      If you're already in a session with OpenCode and something comes up that
+      you'd like to report, just say so. OpenCode can draft the issue title and
+      body based on the conversation and hand you a prefilled link, so all you
+      have to do is review and click Submit.
+    </p>
+
+    <h2 id="going-further"><a href="#going-further" class="heading-anchor">Going further: submit a pull request</a></h2>
+    <p>
+      Filing an issue is the most valuable thing you can do, and it's where
+      most contributions start. If you want to go further and fix or build the
+      thing yourself, the <a href="/exercises/use-git-and-github">Use Git and GitHub</a>
+      exercise walks through forking this repository, making a change, and
+      opening a pull request.
+    </p>
+    <p>
+      For the full details on the development setup, lesson authoring
+      conventions, and how the site is put together, see
+      <a href="https://github.com/opencodeschool/opencode.school/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING.md</a>
+      and
+      <a href="https://github.com/opencodeschool/opencode.school/blob/main/AGENTS.md" target="_blank" rel="noopener noreferrer">AGENTS.md</a>
+      in the repository.
+    </p>
+  </article>
+</Base>

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -44,7 +44,34 @@ When presenting multiple choice questions, do not label any answer choice as "Re
 
 If the student has a problem with OpenCode itself (bugs, crashes, unexpected behavior in the OpenCode tool), direct them to the official Anomaly OpenCode Discord: https://opencode.ai/discord
 
-If the student has a problem with OpenCode School (lesson content, enrollment, progress tracking, site issues), guide them to report it on GitHub: https://github.com/opencodeschool/opencode.school/issues — Walk them through the process: they will need a GitHub account to post an issue. If they don't have one, help them understand how to create a free account at https://github.com/signup, then guide them in writing a clear issue with a descriptive title, steps to reproduce, and what they expected vs. what happened.
+If the student has a problem with OpenCode School (lesson content, enrollment, progress tracking, site issues), guide them to report it on GitHub: https://github.com/opencodeschool/opencode.school/issues — see the "Inviting contributions" section below for how to offer to help draft the issue.
+
+## Inviting contributions
+
+Every friction point a student hits is a signal that could make the course better for the next student. Your job is to notice those signals and invite the student to share them as a GitHub issue. Filing an issue is the primary contribution we're asking for. A pull request is a bonus, never a requirement.
+
+Watch for these signals during a session:
+
+- Confusion: the student is stuck, says "this doesn't make sense", or struggles to follow a lesson or exercise.
+- Mismatch: instructions don't match what the student sees (UI changed, command failed, wrong output).
+- Wishes: "I wish this did X", "it would be nice if", "why doesn't the course cover Y".
+- Novel ideas: the student discovers a prompt or workflow that worked well and seems worth sharing, or proposes a new exercise.
+- Apparent bugs or stale content: broken links, outdated screenshots, incorrect steps.
+
+When you notice a signal:
+
+1. First, help the student unblock on the immediate problem if there is one.
+2. Then offer once to help them file a GitHub issue so the course can improve for future students. Keep it light — this is an invitation, not a gate. If they decline, drop it for the rest of the session and don't bring it up again.
+3. If they say yes, draft the issue title and body from the conversation context. They have the details fresh in your conversation; don't make them rewrite them.
+4. Construct a prefilled URL so they just click, review, and submit:
+   \`https://github.com/opencodeschool/opencode.school/issues/new?title=<url-encoded-title>&body=<url-encoded-body>\`
+   URL-encode spaces as %20 and newlines as %0A. Include enough detail in the body that a maintainer reading the issue cold can understand what happened, where, and why it matters.
+5. Share the URL with the student and tell them they can edit the prefilled text on GitHub before submitting.
+6. If they don't have a GitHub account, point them at https://github.com/signup and offer to walk them through creating one.
+
+Never pressure the student into submitting a pull request. Filing an issue is the success case. If the student is curious about going further, the "Use Git and GitHub" exercise walks through forking this repository and opening a PR.
+
+For the full framing students see on the site, link to \`${origin}/contributing\`.
 
 Students who have completed the Configuration lesson may have ${origin}/api/instructions/{studentId} in their OpenCode config's "instructions" array. If so, you already know their student ID from the instructions loaded at session start — use it without asking.
 

--- a/src/pages/troubleshooting.astro
+++ b/src/pages/troubleshooting.astro
@@ -76,18 +76,16 @@ import Base from "../layouts/Base.astro";
     <h2 id="reporting-an-issue-with-opencode-school"><a href="#reporting-an-issue-with-opencode-school" class="heading-anchor">Reporting an issue with OpenCode School</a></h2>
     <p>
       If you find a problem with this course — a broken lesson, incorrect
-      content, enrollment issues, or anything else on this site — please report
-      it on GitHub:
+      content, enrollment issues, or anything else on this site — or if you
+      have an idea for making the course better, please share it on GitHub.
+      Bug reports, suggestions, and ideas for new lessons or exercises are all
+      welcome.
     </p>
     <p>
-      <a href="https://github.com/opencodeschool/opencode.school/issues" target="_blank" rel="noopener noreferrer">https://github.com/opencodeschool/opencode.school/issues</a>
-    </p>
-    <p>
-      To post an issue you'll need a free GitHub account. If you don't have one,
-      you can create one at <a href="https://github.com/signup" target="_blank" rel="noopener noreferrer">github.com/signup</a>.
-      When writing your issue, include a descriptive title, the steps that led to
-      the problem, and what you expected to happen vs. what actually happened.
-      The more detail you provide, the easier it is to fix.
+      See the <a href="/contributing">Contributing</a> page for the easiest
+      ways to file an issue, including prefilled templates for bug reports,
+      ideas, and exercise proposals. OpenCode can also help draft the issue
+      for you based on your session.
     </p>
 
     <h2 id="disenroll"><a href="#disenroll" class="heading-anchor">How to reset progress or disenroll</a></h2>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -118,14 +118,8 @@
 }
 
 .dark .prose pre.astro-code {
-  /*
-    Deep tinted background using the student's highlight color, roughly
-    equivalent to Tailwind's `-950` shade. Mixing --theme-link-dark
-    (the palette's 300-ish dark-mode color) with black at a low percentage
-    produces a consistent deep tint across all 18 palettes.
-  */
   border: 2px solid color-mix(in srgb, var(--theme-link-dark) 60%, transparent);
-  background: color-mix(in srgb, var(--theme-link-dark) 10%, black) !important;
+  background: theme(--color-stone-900) !important;
   color: theme(--color-stone-300) !important;
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -87,47 +87,52 @@
   .prose :is(h2, h3, h4, h5, h6):hover .heading-anchor::after {
     visibility: visible;
   }
-
 }
 
 /*
-  Theme-aware syntax highlighting.
+  Theme-framed code blocks.
 
-  A Shiki transformer (see astro.config.mjs) strips Shiki's per-token
-  inline colors at build time and tags structural tokens with
-  `.tok-comment` and `.tok-structure`. We then paint everything with the
-  student's chosen theme color, varying only opacity and weight so the
-  scheme stays legible across all 18 palette colors.
+  Code blocks mirror the agent-prompt-box look: a 2px theme-colored
+  border with a soft theme-colored glow and a theme-tinted background.
+  Unlike the agent-prompt card, there's no 6px left border — we want the
+  frame to feel like a subtle highlight, not a callout.
 
-  These rules live outside `@layer base` on purpose: Tailwind Typography
-  defines its prose `pre` / `code` styles inside `@layer utilities`, which
-  would otherwise win regardless of specificity. Unlayered rules beat any
-  layered rule in the cascade, so we declare these here.
+  Vesper bakes per-token `style="color:#..."` into each span at build
+  time, so we neutralize those with `color: inherit !important` on the
+  spans and set a single monochrome ink color on the block.
+
+  These rules live outside `@layer base` because Tailwind Typography
+  emits its prose `pre` / `code` styles inside `@layer utilities`, which
+  wins against any layered rule regardless of specificity. Unlayered
+  declarations beat layered ones in the cascade.
 */
-.prose pre.astro-code,
-.prose :not(pre) > code {
-  background-color: theme(--color-stone-100);
-  color: var(--theme-link);
+.prose pre.astro-code {
+  /* !important overrides Shiki's inline background and color on <pre>. */
+  border: 2px solid var(--theme-solid);
+  background: color-mix(in srgb, var(--theme-soft-bg) 40%, white) !important;
+  color: theme(--color-stone-800) !important;
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--theme-solid) 12%, transparent),
+    0 4px 16px color-mix(in srgb, var(--theme-solid) 15%, transparent);
 }
 
-.dark .prose pre.astro-code,
+.prose pre.astro-code span {
+  color: inherit !important;
+}
+
+.dark .prose pre.astro-code {
+  border: 2px solid color-mix(in srgb, var(--theme-link-dark) 60%, transparent);
+  background: theme(--color-stone-950) !important;
+  color: theme(--color-stone-300) !important;
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--theme-link-dark) 18%, transparent),
+    0 4px 20px color-mix(in srgb, var(--theme-link-dark) 20%, transparent);
+}
+
+/* Inline code inside prose — stone-toned in dark mode for readability */
 .dark .prose :not(pre) > code {
   background-color: theme(--color-stone-800);
-  color: var(--theme-link-dark);
-}
-
-.prose :not(pre) > code {
-  padding: 0.125rem 0.375rem;
-  border-radius: 0.25rem;
-}
-
-.prose pre.astro-code .tok-comment {
-  opacity: 0.5;
-}
-
-.prose pre.astro-code .tok-structure {
-  opacity: 0.7;
-  font-weight: 600;
+  color: theme(--color-stone-300);
 }
 
 @keyframes spin-slow {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -92,10 +92,10 @@
 /*
   Theme-framed code blocks.
 
-  Code blocks mirror the agent-prompt-box look: a 2px theme-colored
-  border with a soft theme-colored glow and a theme-tinted background.
-  Unlike the agent-prompt card, there's no 6px left border — we want the
-  frame to feel like a subtle highlight, not a callout.
+  A 2px theme-colored border plus a lightly theme-tinted background.
+  Inspired by the agent-prompt card but quieter — no box shadow, no
+  heavy left border — so code blocks read as a subtle highlight rather
+  than a callout.
 
   Vesper bakes per-token `style="color:#..."` into each span at build
   time, so we neutralize those with `color: inherit !important` on the
@@ -111,9 +111,6 @@
   border: 2px solid var(--theme-solid);
   background: color-mix(in srgb, var(--theme-soft-bg) 40%, white) !important;
   color: theme(--color-stone-800) !important;
-  box-shadow:
-    0 0 0 3px color-mix(in srgb, var(--theme-solid) 12%, transparent),
-    0 4px 16px color-mix(in srgb, var(--theme-solid) 15%, transparent);
 }
 
 .prose pre.astro-code span {
@@ -122,11 +119,8 @@
 
 .dark .prose pre.astro-code {
   border: 2px solid color-mix(in srgb, var(--theme-link-dark) 60%, transparent);
-  background: theme(--color-stone-950) !important;
+  background: theme(--color-stone-900) !important;
   color: theme(--color-stone-300) !important;
-  box-shadow:
-    0 0 0 3px color-mix(in srgb, var(--theme-link-dark) 18%, transparent),
-    0 4px 20px color-mix(in srgb, var(--theme-link-dark) 20%, transparent);
 }
 
 /* Inline code inside prose — stone-toned in dark mode for readability */

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -88,16 +88,46 @@
     visibility: visible;
   }
 
-  /* Ensure prose code blocks and inline code stay stone-toned in dark mode */
-  .dark .prose pre {
-    background-color: theme(--color-stone-800);
-    color: theme(--color-stone-300);
-  }
+}
 
-  .dark .prose code {
-    background-color: theme(--color-stone-800);
-    color: theme(--color-stone-300);
-  }
+/*
+  Theme-aware syntax highlighting.
+
+  A Shiki transformer (see astro.config.mjs) strips Shiki's per-token
+  inline colors at build time and tags structural tokens with
+  `.tok-comment` and `.tok-structure`. We then paint everything with the
+  student's chosen theme color, varying only opacity and weight so the
+  scheme stays legible across all 18 palette colors.
+
+  These rules live outside `@layer base` on purpose: Tailwind Typography
+  defines its prose `pre` / `code` styles inside `@layer utilities`, which
+  would otherwise win regardless of specificity. Unlayered rules beat any
+  layered rule in the cascade, so we declare these here.
+*/
+.prose pre.astro-code,
+.prose :not(pre) > code {
+  background-color: theme(--color-stone-100);
+  color: var(--theme-link);
+}
+
+.dark .prose pre.astro-code,
+.dark .prose :not(pre) > code {
+  background-color: theme(--color-stone-800);
+  color: var(--theme-link-dark);
+}
+
+.prose :not(pre) > code {
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+}
+
+.prose pre.astro-code .tok-comment {
+  opacity: 0.5;
+}
+
+.prose pre.astro-code .tok-structure {
+  opacity: 0.7;
+  font-weight: 600;
 }
 
 @keyframes spin-slow {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -118,8 +118,14 @@
 }
 
 .dark .prose pre.astro-code {
+  /*
+    Deep tinted background using the student's highlight color, roughly
+    equivalent to Tailwind's `-950` shade. Mixing --theme-link-dark
+    (the palette's 300-ish dark-mode color) with black at a low percentage
+    produces a consistent deep tint across all 18 palettes.
+  */
   border: 2px solid color-mix(in srgb, var(--theme-link-dark) 60%, transparent);
-  background: theme(--color-stone-900) !important;
+  background: color-mix(in srgb, var(--theme-link-dark) 10%, black) !important;
   color: theme(--color-stone-300) !important;
 }
 


### PR DESCRIPTION
This PR styles prose code blocks to match the agent-prompt card look — a theme-colored border, a soft theme-colored glow, and a pale theme-tinted background — minus the 6px left border so the block reads as a subtle highlight rather than a callout.

## What changed

- `src/styles/main.css` — replaced the old dark-mode prose code overrides with a new unlayered block that frames `.prose pre.astro-code` using the same CSS variables that drive the agent-prompt card (`--theme-solid`, `--theme-soft-bg`, `--theme-link-dark`). Text inside code blocks is rendered in a single monochrome ink color (stone-800 light, stone-300 dark); span-level `color: inherit !important` neutralizes Vesper's per-token colors.
- `astro.config.mjs` — no changes from main. The Shiki transformer from the first iteration of this PR is gone.

## Why this approach

The first iteration tried to retint every code token in the student's theme color via a build-time transformer. That worked but felt busy and was more machinery than the problem called for. This version keeps the change scoped to CSS, reuses styling primitives that already exist, and matches the aesthetic of the agent-prompt cards students already see.

The new rules live outside `@layer base` because Tailwind Typography's prose styles are emitted inside `@layer utilities`, which wins against layered rules regardless of specificity.

Closes #13