### PR TITLE
Fix unlinked URL in plugins lesson

### DIFF
--- a/src/content/lessons/10-plugins.mdx
+++ b/src/content/lessons/10-plugins.mdx
@@ -29,7 +29,7 @@ agentInstructions: |
 
   4. Installing a real plugin: walk through installing the Replicate
      plugin as a hands-on example. First get a Replicate API token from
-     replicate.com/account/api-tokens, add
+     [replicate.com/account/api-tokens](https://replicate.com/account/api-tokens), add
      `export REPLICATE_API_TOKEN=r8_your_token_here` to their shell
      profile (.bashrc or .zshrc), then run the quick-install script with
      `curl -sSL https://raw.githubusercontent.com/lucataco/replicate-opencode-plugin/main/install.sh | bash`


### PR DESCRIPTION
Fixes an unlinked URL in the agentInstructions section of the plugins lesson.