### PR TITLE
chore: migrate deployment to DevRel Cloudflare account

### DIFF
--- a/script/clean-progress
+++ b/script/clean-progress
@@ -13,7 +13,7 @@ VALID_EXERCISE_SLUGS=(
   drive-a-browser post-to-social-media use-git-and-github
 )
 
-KV_NAMESPACE_ID="3bd04cd0e35548b181036e6385b5120c"
+KV_NAMESPACE_ID="8ff29749cd3f4b95ba6245727b7ba5e0"
 DRY_RUN=true
 FIXED=0
 SCANNED=0

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,7 +18,7 @@
   "kv_namespaces": [
     {
       "binding": "PROGRESS",
-      "id": "3bd04cd0e35548b181036e6385b5120c"
+      "id": "8ff29749cd3f4b95ba6245727b7ba5e0"
     }
   ],
   "env": {


### PR DESCRIPTION
This PR updates the KV namespace ID in `wrangler.jsonc` and `script/clean-progress` to point at the new namespace in the Developer Relations Cloudflare account.

The GitHub Actions secrets (`CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`) have already been updated to the DevRel account. Once this PR merges, the deploy workflow will deploy to the DevRel account instead of the personal account.

Part of the broader migration from the personal `sikelianos@gmail.com` Cloudflare account to the shared Developer Relations account (`e9bc21da719562a3e45d77de7dd042de`).