### PR TITLE
fix: update preview deploy URL to DevRel workers.dev subdomain

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -52,7 +52,7 @@ jobs:
           gh api repos/${{ github.repository }}/deployments/${{ steps.deployment.outputs.deployment_id }}/statuses \
             --method POST \
             -f state=success \
-            -f environment_url=https://opencodeschool-pr-${{ github.event.pull_request.number }}.ziki.workers.dev \
+            -f environment_url=https://opencodeschool-pr-${{ github.event.pull_request.number }}.examples.workers.dev \
             -f description="Preview deployed"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/agent-plan.md
+++ b/agent-plan.md
@@ -49,8 +49,8 @@ People who are new to agentic coding and may not be comfortable using a terminal
 ## Deployment
 
 - Custom domain: `opencode.school`
-- Workers dev URL: `opencodeschool.ziki.workers.dev`
-- GitHub repo: `zeke/opencode.school`
+- Workers dev URL: `opencodeschool.examples.workers.dev`
+- GitHub repo: `opencodeschool/opencode.school`
 - GitHub Actions: deploy on push to main
 
 ## Project structure


### PR DESCRIPTION
This PR updates the preview deployment URL in the GitHub Actions workflow from `ziki.workers.dev` (personal account) to `examples.workers.dev` (DevRel account), matching the account migration done in #157.

Also updates `agent-plan.md` with the correct workers.dev subdomain and GitHub repo org.

The `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` GitHub secrets have been re-set to working values for the DevRel account.