### PR TITLE
feat: add cheatsheet quick-reference page

### DIFF
--- a/lessons/cheatsheet.md
+++ b/lessons/cheatsheet.md
@@ -1,0 +1,153 @@
+---
+title: "Cheatsheet"
+slug: cheatsheet
+description: "Slash commands, prompt syntax, keyboard shortcuts, CLI commands, and file paths at a glance."
+---
+
+A quick reference drawn from the [OpenCode docs](https://opencode.ai/docs) and the lessons in this course. Most things work in both OpenCode Desktop and the OpenCode [TUI](/glossary#tui); items specific to one or the other are noted.
+
+For deeper context on any item, follow the links to the relevant lesson or to the official docs.
+
+## Slash commands
+
+Type these inside the OpenCode prompt. Type `/` on its own to see the full list of available commands in your current session.
+
+| Command | What it does |
+| --- | --- |
+| `/new` (alias `/clear`) | Start a new [session](/lessons/sessions); the current one stays in your history |
+| `/sessions` (aliases `/resume`, `/continue`) | List and switch between sessions |
+| `/help` | Show the help dialog and the list of available commands |
+| `/init` | Guided setup for creating or updating a project-level `AGENTS.md` — see [Instructions](/lessons/instructions) |
+| `/connect` | Add a model provider and configure its API key (TUI) |
+| `/models` | Open the model picker to switch [models](/lessons/models) |
+| `/mcp` | List configured MCP servers and their connection status — see [Tools](/lessons/tools) |
+| `/themes` | List and switch between themes (TUI) |
+| `/share` | Share the current session as a public link at `opncd.ai/s/<id>` |
+| `/unshare` | Stop sharing the current session and remove the shared data |
+| `/undo` | Revert the last user message and any file changes the agent made — run multiple times to keep undoing |
+| `/redo` | Restore a message and its file changes after `/undo` |
+| `/compact` (alias `/summarize`) | Summarize the current session to free up context window space |
+| `/details` | Toggle whether tool execution details are shown inline |
+| `/thinking` | Toggle visibility of the model's reasoning blocks (display only — does not change model capability) |
+| `/editor` | Open the editor set in `$EDITOR` to compose a longer message (TUI) |
+| `/export` | Export the current conversation as Markdown and open in `$EDITOR` (TUI) |
+| `/exit` (aliases `/quit`, `/q`) | Exit OpenCode (TUI) |
+| `/<your command>` | Run a [custom command](/lessons/commands) you've defined in `~/.config/opencode/commands/` or `.opencode/commands/` |
+
+> **Note:** `/undo` and `/redo` use Git under the hood, so they only work in projects that are Git repositories.
+
+## Prompt syntax
+
+Special characters that change how a prompt is interpreted.
+
+| Syntax | What it does |
+| --- | --- |
+| `@<path>` | Reference a file or directory; fuzzy search runs as you type, and the file's contents are added to the conversation (e.g. `Explain @src/index.ts`) |
+| `!<command>` | Run a shell command from the prompt; the output is added to the conversation as a tool result (e.g. `!ls -la`) |
+
+## Keyboard shortcuts
+
+### Desktop and TUI (shared)
+
+| Shortcut | What it does |
+| --- | --- |
+| `Return` / `Enter` | Send the current message |
+| `Shift+Return` (or `Ctrl+Return`, `Alt+Return`, `Ctrl+J`) | Insert a newline in the prompt without sending |
+| `Cmd+V` (Mac) / `Ctrl+V` (Windows/Linux) | Paste an [image](/lessons/images) or text from the clipboard into the prompt |
+| Drag and drop | Drag an image file from your desktop or file manager into the OpenCode window to attach it |
+| `Esc` | Interrupt a running response or close popovers |
+
+### Prompt input editing (Readline / Emacs style)
+
+Built into the OpenCode Desktop prompt input. The TUI has equivalent `input_*` bindings that can be remapped in `tui.json`.
+
+| Shortcut | What it does |
+| --- | --- |
+| `Ctrl+A` | Move to start of current line |
+| `Ctrl+E` | Move to end of current line |
+| `Ctrl+B` / `Ctrl+F` | Move cursor back / forward one character |
+| `Alt+B` / `Alt+F` | Move cursor back / forward one word |
+| `Ctrl+D` | Delete character under cursor |
+| `Ctrl+K` | Delete to end of line |
+| `Ctrl+U` | Delete to start of line |
+| `Ctrl+W` | Delete previous word |
+| `Alt+D` | Delete next word |
+| `Ctrl+T` | Transpose characters (Desktop only — in the TUI, `Ctrl+T` cycles model variants) |
+| `Ctrl+G` | Cancel popovers / abort running response |
+
+### TUI keybinds
+
+The TUI uses `Ctrl+X` as the leader key by default — press `Ctrl+X`, release, then press the next key. You can change the leader and any binding in `tui.json`. See the [keybinds docs](https://opencode.ai/docs/keybinds) for the full list.
+
+**Leader combos**
+
+| Shortcut | What it does |
+| --- | --- |
+| `Ctrl+X N` | New session |
+| `Ctrl+X L` | List sessions |
+| `Ctrl+X C` | Compact session |
+| `Ctrl+X U` | Undo last message |
+| `Ctrl+X R` | Redo last undone message |
+| `Ctrl+X X` | Export conversation |
+| `Ctrl+X E` | Open external editor |
+| `Ctrl+X M` | Model picker |
+| `Ctrl+X T` | Theme picker |
+| `Ctrl+X A` | Agent picker |
+| `Ctrl+X Q` | Quit |
+| `Ctrl+X B` | Toggle sidebar |
+| `Ctrl+X S` | Status view |
+| `Ctrl+X Y` | Copy last message |
+
+**Standalone**
+
+| Shortcut | What it does |
+| --- | --- |
+| `Tab` / `Shift+Tab` | Cycle [agents](/lessons/agents) (Plan ↔ Build) — Desktop uses the agent dropdown below the prompt instead |
+| `Ctrl+P` | Command palette |
+| `Ctrl+T` | Cycle model variants (e.g. reasoning on/off) |
+| `F2` / `Shift+F2` | Cycle through recently used models |
+| `Ctrl+R` | Rename current session |
+
+## CLI commands
+
+Type these in your terminal, not in the OpenCode prompt. The `opencode` CLI ships with both OpenCode Desktop and the standalone TUI install. For the full list of subcommands and flags, see the [CLI docs](https://opencode.ai/docs/cli).
+
+| Command | What it does |
+| --- | --- |
+| `opencode run "<prompt>"` | Run a single prompt non-interactively and exit |
+| `opencode session list` | List every [session](/lessons/sessions) across all your projects |
+| `opencode export [sessionID]` | Export a session as JSON; prompts you to pick if the ID is omitted |
+| `opencode mcp auth [name]` | Authenticate an OAuth-enabled MCP server — see [Tools](/lessons/tools) |
+| `opencode mcp auth list` (alias `ls`) | Show OAuth status for all configured servers |
+| `opencode mcp debug <name>` | Print debug info for an MCP server connection |
+
+## File paths
+
+Where OpenCode looks for config and customization files. Global paths apply to every project; per-project paths apply only inside that project.
+
+### Global
+
+| Path | What it is |
+| --- | --- |
+| `~/.config/opencode/opencode.json` | Main config: providers, permissions, MCP servers, etc |
+| `~/.config/opencode/AGENTS.md` | Custom [instructions](/lessons/instructions) loaded at the start of every session |
+| `~/.config/opencode/commands/` | Custom [slash commands](/lessons/commands) |
+| `~/.config/opencode/skills/` | Reusable [skills](/lessons/skills) |
+| `~/.config/opencode/plugins/` | JS/TS [plugins](/lessons/plugins) that extend OpenCode |
+
+### Per-project
+
+| Path | What it is |
+| --- | --- |
+| `<project>/AGENTS.md` | Project-specific instructions, typically committed to Git |
+| `<project>/.opencode/opencode.json` | Project-specific config overrides |
+| `<project>/.opencode/commands/` | Project-specific slash commands |
+| `<project>/.opencode/skills/` | Project-specific skills |
+| `<project>/.opencode/plugins/` | Project-specific plugins |
+
+## Where to look next
+
+- The [OpenCode docs](https://opencode.ai/docs) are the canonical reference for everything above.
+- The [keybinds docs](https://opencode.ai/docs/keybinds) cover every default TUI binding and how to remap them in `tui.json`.
+- The [CLI docs](https://opencode.ai/docs/cli) document every flag and subcommand in detail.
+- The [Glossary](/glossary) defines the terms used throughout this cheatsheet and the lessons.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1703,9 +1703,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1721,9 +1718,6 @@
       "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -1741,9 +1735,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1759,9 +1750,6 @@
       "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -661,6 +661,17 @@ const currentPath = Astro.url.pathname;
             Tips
           </a>
           <a
+            href="/cheatsheet"
+            class:list={[
+              "block px-3 py-1.5 rounded-md text-sm transition-colors",
+              currentPath === "/cheatsheet" || currentPath === "/cheatsheet/"
+                ? "theme-active-nav font-medium"
+                : "text-gray-600 hover:text-gray-900 hover:bg-gray-50 dark:text-stone-400 dark:hover:text-stone-200 dark:hover:bg-stone-800",
+            ]}
+          >
+            Cheatsheet
+          </a>
+          <a
             href="/changelog"
             class:list={[
               "block px-3 py-1.5 rounded-md text-sm transition-colors",

--- a/src/pages/cheatsheet.astro
+++ b/src/pages/cheatsheet.astro
@@ -1,0 +1,34 @@
+---
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export const prerender = true;
+
+import Base from "../layouts/Base.astro";
+import { marked } from "marked";
+import cheatsheetRaw from "../../lessons/cheatsheet.md?raw";
+
+const renderer = new marked.Renderer();
+renderer.heading = function ({ text, depth }) {
+  const slug = text.toLowerCase().replace(/[^\w]+/g, "-").replace(/(^-|-$)/g, "");
+  return `<h${depth} id="${slug}"><a href="#${slug}" class="heading-anchor">${text}</a></h${depth}>`;
+};
+
+const body = cheatsheetRaw.replace(/^---[\s\S]*?---\n/, "");
+const html = await marked(body, { renderer });
+---
+
+<Base title="Cheatsheet" description="Slash commands, prompt syntax, keyboard shortcuts, CLI commands, and file paths at a glance.">
+  <div class="mb-6">
+    <a href="/" class="text-sm text-gray-500 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors">
+      &larr; All lessons
+    </a>
+  </div>
+
+  <header class="mb-8">
+    <h1 class="text-3xl font-bold">Cheatsheet</h1>
+    <p class="text-gray-600 dark:text-stone-400 mt-2">Slash commands, prompt syntax, keyboard shortcuts, CLI commands, and file paths at a glance.</p>
+  </header>
+
+  <article class="prose dark:prose-invert max-w-none" set:html={html} />
+</Base>


### PR DESCRIPTION
This PR adds a `/cheatsheet` page with a quick reference for OpenCode users — slash commands, prompt syntax, keyboard shortcuts, CLI commands, and file paths.
## What's on the page
- **Slash commands** — every built-in `/command` with a one-line description and links to the relevant lesson.
- **Prompt syntax** — `@<path>` file references and `!<command>` shell escapes.
- **Keyboard shortcuts** — three sections: shared (Desktop + TUI), prompt input editing (Readline/Emacs style), and TUI-specific keybinds including the `Ctrl+X` leader combos.
- **CLI commands** — the `opencode run`, `session`, `export`, and `mcp` subcommands.
- **File paths** — global (`~/.config/opencode/`) and per-project (`.opencode/`) config and customization directories.
Each entry links to the relevant lesson or upstream docs for deeper context.
## How it's structured
- Source content lives at `lessons/cheatsheet.md` so it can be edited as plain Markdown without touching component code.
- `src/pages/cheatsheet.astro` reads the markdown via `?raw`, strips frontmatter, and renders it through `marked` with a custom heading renderer that produces anchor links matching the existing `prose .heading-anchor` style.
- A "Cheatsheet" link is added to the sidebar in `Base.astro`, between Tips and Changelog.