### PR TITLE
feat: add Cloudflare AI Search modal, robots.txt, and sitemap

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,18 +2,79 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import cloudflare from "@astrojs/cloudflare";
 import mdx from "@astrojs/mdx";
+import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
+import { parse as parseJsonc } from "jsonc-parser";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeSlug from "rehype-slug";
+import { changelogEntries } from "./src/lib/changelog.ts";
+
+// Read public, non-secret values from wrangler.jsonc so the deployment config
+// is the single source of truth. These get inlined into the build, which is
+// needed because all human-facing pages are prerendered — runtime `env`
+// bindings aren't available when the HTML is generated.
+const projectRoot = dirname(fileURLToPath(import.meta.url));
+const wranglerConfig = parseJsonc(
+	readFileSync(resolve(projectRoot, "wrangler.jsonc"), "utf-8"),
+);
+const wranglerVars = wranglerConfig?.vars ?? {};
+const siteUrl = wranglerVars.SITE_URL || "https://opencode.school";
+const aiSearchApiUrl = wranglerVars.AI_SEARCH_API_URL ?? "";
+
+// Map of changelog slugs to their dates for setting <lastmod> in the sitemap.
+const changelogLastmod = new Map(
+	changelogEntries.map((entry) => [entry.slug, entry.date]),
+);
+
+// Per-page priority based on URL path. Higher = more important to index first.
+function priorityFor(path) {
+	if (path === "/") return 1.0;
+	if (path.startsWith("/lessons/")) return 0.9;
+	if (path === "/exercises" || path.startsWith("/exercises/")) return 0.8;
+	if (path === "/about" || path === "/tips") return 0.6;
+	if (
+		path === "/contributing" ||
+		path === "/glossary" ||
+		path === "/troubleshooting"
+	)
+		return 0.5;
+	if (path === "/changelog") return 0.4;
+	if (path === "/disenroll" || path.startsWith("/changelog/")) return 0.3;
+	return undefined;
+}
 
 export default defineConfig({
-	site: "https://opencode.school",
+	site: siteUrl,
 	output: "server",
 	adapter: cloudflare(),
-	integrations: [mdx()],
+	integrations: [
+		mdx(),
+		sitemap({
+			// Exclude prerendered routes that aren't search-relevant. /api/* and
+			// /llms.txt are SSR-only so they're already excluded automatically.
+			filter: (page) => {
+				const path = new URL(page).pathname.replace(/\/$/, "") || "/";
+				return path !== "/404" && path !== "/changelog.xml";
+			},
+			serialize(item) {
+				const path = new URL(item.url).pathname.replace(/\/$/, "") || "/";
+				const priority = priorityFor(path);
+				if (priority !== undefined) item.priority = priority;
+				const changelogMatch = path.match(/^\/changelog\/(.+)$/);
+				if (changelogMatch) {
+					const lastmod = changelogLastmod.get(changelogMatch[1]);
+					if (lastmod) item.lastmod = lastmod;
+				}
+				return item;
+			},
+		}),
+	],
 	markdown: {
 		rehypePlugins: [
 			rehypeSlug,
@@ -31,5 +92,8 @@ export default defineConfig({
 	},
 	vite: {
 		plugins: [tailwindcss()],
+		define: {
+			__AI_SEARCH_API_URL__: JSON.stringify(aiSearchApiUrl),
+		},
 	},
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@astrojs/cloudflare": "^13.1.1",
         "@astrojs/mdx": "^5.0.0",
         "@astrojs/rss": "^4.0.18",
+        "@astrojs/sitemap": "^3.7.2",
+        "@cloudflare/ai-search-snippet": "^0.0.39",
         "@fontsource/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@resvg/resvg-js": "^2.6.2",
@@ -26,6 +28,7 @@
         "@cloudflare/workers-types": "^4.20260313.1",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.1",
+        "jsonc-parser": "^3.3.1",
         "tailwindcss": "^4.2.1",
         "vitest": "^4.1.0",
         "wrangler": "^4.73.0"
@@ -139,6 +142,17 @@
       "dependencies": {
         "fast-xml-parser": "^5.5.7",
         "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
         "zod": "^4.3.6"
       }
     },
@@ -404,6 +418,15 @@
       "dependencies": {
         "@clack/core": "1.1.0",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@cloudflare/ai-search-snippet": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@cloudflare/ai-search-snippet/-/ai-search-snippet-0.0.39.tgz",
+      "integrity": "sha512-1d9iyB9hZP2Zt+VfOMD/WEetyGZKmslB4BG7Lfi9bJZhNQFZELzoQ7ATWfcG7H2Zc856njQnqNJ8V/TeGhFmOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -1703,9 +1726,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1721,9 +1741,6 @@
       "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -1741,9 +1758,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1759,9 +1773,6 @@
       "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -2680,6 +2691,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2850,6 +2879,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4316,6 +4351,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -6614,6 +6656,25 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
@@ -6666,6 +6727,12 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
     "node_modules/string.prototype.codepointat": {
@@ -6906,6 +6973,12 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@astrojs/cloudflare": "^13.1.1",
     "@astrojs/mdx": "^5.0.0",
     "@astrojs/rss": "^4.0.18",
+    "@astrojs/sitemap": "^3.7.2",
+    "@cloudflare/ai-search-snippet": "^0.0.39",
     "@fontsource/inter": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@resvg/resvg-js": "^2.6.2",
@@ -36,6 +38,7 @@
     "@cloudflare/workers-types": "^4.20260313.1",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.1",
+    "jsonc-parser": "^3.3.1",
     "tailwindcss": "^4.2.1",
     "vitest": "^4.1.0",
     "wrangler": "^4.73.0"

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -4,6 +4,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 import "../styles/main.css";
 import { getCollection } from "astro:content";
+import { AI_SEARCH_API_URL } from "../lib/ai-search";
 
 interface Props {
   title?: string;
@@ -542,18 +543,47 @@ const currentPath = Astro.url.pathname;
     <script defer src="https://cloud.umami.is/script.js" data-website-id="a3d79131-e6af-4376-b614-b7bd60af46f8"></script>
   </head>
   <body class="min-h-screen">
-    <!-- Fixed GitHub corner icon (desktop only) -->
-    <a
-      href="https://github.com/opencodeschool/opencode.school"
-      target="_blank"
-      rel="noopener noreferrer"
-      class="hidden lg:block fixed top-5 right-5 z-40 text-gray-400 hover:text-gray-600 dark:text-stone-600 dark:hover:text-stone-400 transition-colors"
-      aria-label="Open source on GitHub"
-    >
-      <svg class="w-7 h-7" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-        <path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.342-3.369-1.342-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-      </svg>
-    </a>
+    <!-- Fixed corner icons (desktop only): AI search trigger + GitHub link.
+         The search trigger only renders when AI_SEARCH_API_URL is set in
+         wrangler.jsonc. The GitHub icon is always shown. -->
+    <div class="hidden lg:flex fixed top-5 right-5 z-40 items-center gap-3">
+      {AI_SEARCH_API_URL && (
+        <button
+          id="search-trigger"
+          type="button"
+          class="text-gray-400 hover:text-gray-600 dark:text-stone-600 dark:hover:text-stone-400 transition-colors cursor-pointer"
+          aria-label="Search"
+          title="Search (⌘K / Ctrl+K)"
+        >
+          <svg class="w-7 h-7" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="11" cy="11" r="8"></circle>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+          </svg>
+        </button>
+      )}
+      <a
+        href="https://github.com/opencodeschool/opencode.school"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-gray-400 hover:text-gray-600 dark:text-stone-600 dark:hover:text-stone-400 transition-colors"
+        aria-label="Open source on GitHub"
+      >
+        <svg class="w-7 h-7" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.342-3.369-1.342-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+        </svg>
+      </a>
+    </div>
+
+    {AI_SEARCH_API_URL && (
+      <!-- Cloudflare AI Search modal. Triggered by the search button above or Cmd/Ctrl+K. -->
+      <search-modal-snippet
+        api-url={AI_SEARCH_API_URL}
+        placeholder="Search lessons, exercises, and more..."
+        shortcut="k"
+        show-date="true"
+        hide-branding="true"
+      ></search-modal-snippet>
+    )}
     <div class="lg:flex">
       <!-- Mobile header -->
       <header class="lg:hidden flex items-center justify-between p-4 border-b border-gray-200 dark:border-stone-800">
@@ -825,5 +855,23 @@ const currentPath = Astro.url.pathname;
         }
       })();
     </script>
+
+    {AI_SEARCH_API_URL && (
+      <!-- Load the Cloudflare AI Search web components and wire up the corner search button. -->
+      <script>
+        import "@cloudflare/ai-search-snippet";
+
+        customElements.whenDefined("search-modal-snippet").then(() => {
+          const trigger = document.getElementById("search-trigger");
+          const modal = document.querySelector("search-modal-snippet") as
+            | (HTMLElement & { open?: () => void })
+            | null;
+          if (!trigger || !modal) return;
+          trigger.addEventListener("click", () => {
+            if (typeof modal.open === "function") modal.open();
+          });
+        });
+      </script>
+    )}
   </body>
 </html>

--- a/src/lib/ai-search.ts
+++ b/src/lib/ai-search.ts
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// The Cloudflare AI Search instance URL is configured in wrangler.jsonc under
+// `vars.AI_SEARCH_API_URL`. `astro.config.mjs` reads that value at build time
+// and inlines it here via Vite's `define`. Leave the var empty in
+// wrangler.jsonc to disable the search UI entirely.
+declare const __AI_SEARCH_API_URL__: string;
+
+export const AI_SEARCH_API_URL: string = __AI_SEARCH_API_URL__;

--- a/src/pages/changelog.xml.ts
+++ b/src/pages/changelog.xml.ts
@@ -11,7 +11,9 @@ export function GET(context: APIContext) {
 	return rss({
 		title: "OpenCode School Changelog",
 		description: "What's new on OpenCode School.",
-		site: context.site?.toString() ?? "https://opencode.school",
+		// `context.site` always comes from `astro.config.mjs`, which now reads
+		// SITE_URL from wrangler.jsonc. The fallback is just to satisfy types.
+		site: context.site?.toString() ?? "/",
 		items: changelogEntries.map((entry) => ({
 			title: entry.title,
 			description: entry.description,

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = (context) => {
+	const origin = new URL(context.request.url).origin;
+	const content = `User-agent: *
+Allow: /
+
+Sitemap: ${origin}/sitemap-index.xml
+`;
+	return new Response(content, {
+		status: 200,
+		headers: { "Content-Type": "text/plain; charset=utf-8" },
+	});
+};

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -148,6 +148,31 @@
   border-top-color: var(--theme-link-dark);
 }
 
+/*
+  Cloudflare AI Search widget theme integration.
+
+  The widget exposes ~50 CSS variables under the --search-snippet-* prefix.
+  We override only the few that drive accent and typography so the widget
+  inherits the active student color theme and the site's font stack.
+  Everything else falls back to the widget's own light/dark defaults.
+*/
+search-modal-snippet,
+search-bar-snippet,
+chat-bubble-snippet,
+chat-page-snippet {
+  --search-snippet-primary-color: var(--theme-link);
+  --search-snippet-primary-hover: var(--theme-solid-hover);
+  --search-snippet-font-family: var(--font-sans);
+  --search-snippet-font-family-mono: var(--font-mono);
+}
+
+.dark search-modal-snippet,
+.dark search-bar-snippet,
+.dark chat-bubble-snippet,
+.dark chat-page-snippet {
+  --search-snippet-primary-color: var(--theme-link-dark);
+}
+
 .theme-link {
   color: var(--theme-link);
   transition: color 150ms ease;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,7 +4,18 @@
   "compatibility_date": "2026-03-12",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
-    "directory": "./dist"
+    "directory": "./dist",
+  },
+  // Public, non-secret values read by `astro.config.mjs` at build time and
+  // inlined into the prerendered HTML.
+  //   - SITE_URL drives canonical URLs, OG image URLs, the sitemap, and the
+  //     RSS feed. Change this when deploying to a different domain.
+  //   - AI_SEARCH_API_URL is the Cloudflare AI Search instance the search
+  //     widget queries. Manage the instance at:
+  //       https://dash.cloudflare.com/?to=/:account/ai/ai-search
+  "vars": {
+    "SITE_URL": "https://opencodeschool.conflare.workers.dev",
+    "AI_SEARCH_API_URL": "https://b2003c29-236c-4271-a658-54d0ab255dfb.search.ai.cloudflare.com",
   },
   // The R2 bucket and KV namespace below are for the production deployment.
   // You only need these if you're deploying to your own Cloudflare account.
@@ -12,23 +23,23 @@
   "r2_buckets": [
     {
       "binding": "ASSETS_BUCKET",
-      "bucket_name": "opencodeschool-assets"
-    }
+      "bucket_name": "opencodeschool-assets",
+    },
   ],
   "kv_namespaces": [
     {
       "binding": "PROGRESS",
-      "id": "8ff29749cd3f4b95ba6245727b7ba5e0"
-    }
+      "id": "ef33b4b6ae0f4b80916d91445154380e",
+    },
   ],
   "env": {
     "production": {
       "routes": [
         {
           "pattern": "opencode.school",
-          "custom_domain": true
-        }
-      ]
-    }
-  }
+          "custom_domain": true,
+        },
+      ],
+    },
+  },
 }


### PR DESCRIPTION
This PR adds a site-wide search modal powered by [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/), along with the supporting `robots.txt` and `sitemap-index.xml` that AI Search needs in order to crawl the site. 
> You can view a preview of this feature [here](https://opencodeschool.conflare.workers.dev/)

## What's new
- A search trigger button is now fixed to the top-right corner next to the GitHub icon (desktop only). Clicking it — or pressing `Cmd+K` / `Ctrl+K` — opens a command-palette-style search modal that queries the AI Search instance.
- `/robots.txt` and `/sitemap-index.xml` are now generated. The sitemap covers all 14 lessons, 9 exercises, 31 changelog entries, and 9 top-level pages (excluding `/404`, `/changelog.xml`, `/api/*`, and `/llms.txt`). Lessons get priority 0.9, exercises 0.8, changelog entries 0.3 with `<lastmod>` dates, etc.
## How it's wired up
- `@cloudflare/ai-search-snippet` provides the `<search-modal-snippet>` web component. It's bundled by Astro and registered client-side in `Base.astro`.
- `@astrojs/sitemap` generates the sitemap at build time, with a `serialize` callback that applies per-path priorities and `<lastmod>` for changelog entries.
- The widget inherits the active student color theme via four CSS variable overrides in `main.css` (`--search-snippet-primary-color`, `--search-snippet-primary-hover`, `--search-snippet-font-family`, `--search-snippet-font-family-mono`), with a dark-mode swap to `--theme-link-dark`.
## Configuration via `wrangler.jsonc`
Two new public vars are read at build time and inlined into the prerendered HTML (necessary because runtime `env` bindings aren't available when prerendered pages are generated):
```jsonc
"vars": {
  "SITE_URL": "https://opencode.school",
  "AI_SEARCH_API_URL": "https://<instance>.search.ai.cloudflare.com"
}
```
- `SITE_URL` drives canonical URLs, OG image URLs, the sitemap, and the RSS feed. Change this to deploy to a different hostname.
- `AI_SEARCH_API_URL` is the Cloudflare AI Search instance the widget queries. Leave it empty to disable the search UI entirely (the trigger button and modal won't render and the widget JS won't be referenced).
`astro.config.mjs` parses `wrangler.jsonc` with `jsonc-parser`, exposes `AI_SEARCH_API_URL` via Vite `define`, and feeds `SITE_URL` to the top-level `site` option.
