### PR TITLE
fix(ci): skip preview deploys for fork PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   deploy-preview:
-    if: github.event.action != 'closed'
+    # Skip for fork PRs: GITHUB_TOKEN is read-only and CLOUDFLARE_API_TOKEN
+    # is not exposed to pull_request runs from forks.
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -58,7 +60,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   cleanup-preview:
-    if: github.event.action == 'closed'
+    # Skip for fork PRs (no preview was deployed for them).
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
This PR conditions the `deploy-preview` and `cleanup-preview` jobs in `.github/workflows/preview.yml` on the PR coming from the same repo as the base.

Fork PRs were failing the `Create GitHub Deployment` step with `gh: Resource not accessible by integration (HTTP 403)`. `pull_request` runs from forks get a read-only `GITHUB_TOKEN`, so `POST /repos/.../deployments` is rejected. The wrangler deploy step would also have failed because `secrets.CLOUDFLARE_API_TOKEN` is not exposed to fork PRs.

Skipping both jobs for fork PRs removes the spurious red check. Fork PRs no longer get an automatic preview deploy; same-repo PRs are unaffected.

Unblocks #177 and #178.