### PR TITLE
fix(search): update AI Search API URL

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,7 +17,7 @@
   //       https://dash.cloudflare.com/?to=/:account/ai/ai-search
   "vars": {
     "SITE_URL": "https://opencode.school",
-    "AI_SEARCH_API_URL": "https://a0c9576f-1b8e-4024-8628-51e34c6d34fe.search.ai.cloudflare.com",
+    "AI_SEARCH_API_URL": "https://c16d5e20-b6d1-427a-bdcc-83cf6059d16e.search.ai.cloudflare.com",
   },
   // The R2 bucket and KV namespace below are for the production deployment.
   // You only need these if you're deploying to your own Cloudflare account.


### PR DESCRIPTION
After #180 deployed, the AI Search instance was recreated with the website source attached (couldn't be done at create time because the sitemap didn't exist yet). Recreating produced a new public endpoint UUID. This PR updates wrangler.jsonc to match.

Sync is already running against the new instance.