### PR TITLE
feat(search): boost lessons and exercises in search results

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -42,6 +42,12 @@ const currentPath = Astro.url.pathname;
     <meta name="twitter:title" content={pageTitle} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImageUrl} />
+    {/* Custom metadata for AI Search ranking. Lessons rank above exercises;
+        everything else has no priority and falls below both groups. The
+        AI Search instance has a `content_priority` (number) field defined
+        in its custom_metadata schema. */}
+    {currentPath.startsWith("/lessons/") && <meta name="content_priority" content="2" />}
+    {currentPath.startsWith("/exercises/") && <meta name="content_priority" content="1" />}
     <title>{pageTitle}</title>
     {rssHref && <link rel="alternate" type="application/rss+xml" title="OpenCode School Changelog" href={rssHref} />}
     <script is:inline>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -15,7 +15,7 @@ export const changelogEntries: ChangelogEntry[] = [
 		date: "2026-05-04",
 		title: "Site search",
 		description:
-			"You can now search lessons, exercises, and changelog entries from any page. Click the magnifying glass in the top-right corner or press ⌘K (Ctrl+K on Windows/Linux) to open the search modal. Powered by [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/), with the search UI contributed by [Confidence Okoghenun](https://github.com/megaconfidence).",
+			"You can now search lessons, exercises, and changelog entries from any page. Click the magnifying glass in the top-right corner or press ⌘K (Ctrl+K on Windows/Linux) to open the search modal. Powered by [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/).\n\nThanks to [Confidence Okoghenun](https://github.com/megaconfidence) for the open-source contribution 🧡",
 	},
 	{
 		slug: "config-permission-overrides",


### PR DESCRIPTION
This PR adds the foundation for boosting lessons and exercises in site search results.

Each lesson page now emits `<meta name="content_priority" content="2">` and each exercise page emits `<meta name="content_priority" content="1">`. Other pages (changelog, glossary, etc.) emit no tag.

Two related changes ship in this PR:

1. The meta tags so AI Search can extract them on its next index pass.
2. A small tweak to the site-search changelog entry: the thanks-to-Confidence note now lives on its own paragraph for clarity.

After this deploys, the AI Search instance's `custom_metadata` schema needs to be updated to add a `content_priority` (number) field, which triggers a full re-index. Once the index is rebuilt with the new metadata, a follow-up PR will turn on `boost_by` in the search modal so the new field actually affects ranking.

Pulled out into two PRs to avoid a window where the snippet sends a `boost_by` referencing a field AI Search has just defined but not finished indexing.