### PR TITLE
fix: update Replicate skill install URL on Run AI Models exercise

### DIFF
--- a/src/content/exercises/02-run-ai-models.mdx
+++ b/src/content/exercises/02-run-ai-models.mdx
@@ -8,7 +8,7 @@ agentInstructions: |
   it installed (check ~/.config/opencode/skills/replicate/ or
   ~/.agents/skills/replicate/ for a SKILL.md file), stop and help them
   install it first with
-  `npx skills add https://github.com/replicate/replicate-skill`. The
+  `npx skills add replicate/skills`. The
   skill must be loaded before proceeding.
 
   Guide the student through these steps, adapting depth to their profile:
@@ -60,7 +60,7 @@ You'll generate images with [Nano Banana 2](https://replicate.com/google/nano-ba
 This exercise requires the **Replicate skill** for OpenCode. If you completed the [Skills lesson](/lessons/skills), you already have it installed. If not, install it now:
 
 ```
-npx skills add https://github.com/replicate/replicate-skill
+npx skills add replicate/skills
 ```
 
 You'll also need a **Replicate account** and API token:


### PR DESCRIPTION
This PR fixes the broken `npx skills add` URL on the [Run AI Models](https://opencode.school/exercises/run-ai-models/) exercise page. The old URL (`github.com/replicate/replicate-skill`) returns 404. Updated to the `replicate/skills` shorthand so it matches the install command on the [Skills lesson](https://opencode.school/lessons/skills).

Thanks @jamesqquick for catching this!

Closes #176