### PR TITLE
docs(exercises): emphasize GitHub Desktop and require gh CLI in git exercise

### DIFF
--- a/src/content/exercises/07-use-git-and-github.mdx
+++ b/src/content/exercises/07-use-git-and-github.mdx
@@ -171,33 +171,19 @@ The two are easy to mix up: Git is the tool that tracks changes on your machine,
 
 The recommended starting point is to install [GitHub Desktop](https://desktop.github.com/). It is the easiest way to get from zero to a working Git setup, because it does three things in one install:
 
-1. Installs Git on your machine, so commands like `git --version` and `git push` work in your terminal.
+1. Installs Git on your machine.
 2. Lets you sign up for GitHub or sign in to an existing account directly from the app.
-3. Authenticates the Git CLI for you, so you can push to GitHub from the command line without setting up SSH keys or personal access tokens.
+3. Authenticates the Git CLI for you, so you can push to GitHub without setting up SSH keys or personal access tokens.
 
-Once you've cloned or created a repository in GitHub Desktop, it also gives you a GUI for browsing your project's history and visualizing exactly what changed in each commit. That visualization is the simplest way to review what OpenCode did to your files: every addition is highlighted in green, every removal in red.
+Once you've cloned or created a repository in GitHub Desktop, it also gives you a GUI for browsing your project's history and visualizing exactly what changed in each commit. That visualization is the simplest way to review what OpenCode did to your files.
 
 If you already have Git and a GitHub account, you can skip GitHub Desktop. The exercise still works.
 
 ## Install the gh CLI
 
-The [`gh` CLI](https://cli.github.com/) is GitHub's official command-line tool. Installing it is required for this exercise. The reason is simple: with `gh` installed, OpenCode can read issues, open pull requests, fetch PR diffs, leave comments, check CI status, and create repositories on your behalf, all without you leaving your OpenCode session or clicking around on github.com.
+The [`gh` CLI](https://cli.github.com/) is GitHub's official command-line tool. With `gh` installed, OpenCode can read issues, open pull requests, fetch PR diffs, leave comments, check CI status, and create repositories on your behalf, all without you leaving your session.
 
-Install it for your platform:
-
-- macOS: `brew install gh`
-- Windows: `winget install --id GitHub.cli`
-- Linux: follow the [official Linux instructions](https://github.com/cli/cli/blob/trunk/docs/install_linux.md)
-
-Then authenticate:
-
-```
-gh auth login
-```
-
-The web flow is the fastest path. Note that signing in to GitHub Desktop does not authenticate `gh` for you, so you need this step even if Desktop is already set up. Verify with `gh auth status`.
-
-While you're at it, OpenCode will offer to add a rule to your global `~/.config/opencode/AGENTS.md` reminding it to prefer `gh` for any GitHub task. Say yes if you'd like every future session to default to using the CLI for issues, PRs, and repos.
+You'll install it as part of this exercise and start using it from OpenCode right away.
 
 ## What you'll do
 

--- a/src/content/exercises/07-use-git-and-github.mdx
+++ b/src/content/exercises/07-use-git-and-github.mdx
@@ -10,49 +10,86 @@ agentInstructions: |
 
   Core steps (always do these):
 
-  1. Check if Git is installed by running `git --version`. If not,
-     recommend installing GitHub Desktop from https://desktop.github.com/,
-     which bundles Git, helps create a GitHub account, and authenticates
-     the CLI automatically. If the student prefers, they can install Git
-     directly: `brew install git` on macOS, or download from
-     https://git-scm.com for other platforms.
+  1. Install GitHub Desktop as the primary on-ramp. Direct the student to
+     https://desktop.github.com/ and have them install it. Explain why
+     this is the recommended starting point: GitHub Desktop bundles three
+     things into one install. It installs Git on their machine, it lets
+     them sign up for or sign in to GitHub from the app, and it
+     authenticates the Git CLI so commands like `git push` just work
+     afterward. Once a repo is open in GitHub Desktop, it also gives them
+     a GUI for visualizing exactly what changed in each commit, which is
+     the easiest way to review what OpenCode did to their files.
 
-  2. Explain what Git is: a version control system that records every
+     If the student already has Git installed and a GitHub account, they
+     can still install GitHub Desktop for the diff GUI, or skip it. Verify
+     Git is available with `git --version` either way.
+
+  2. Install the gh CLI. This is required for this exercise, not optional.
+     Explain why: agents like OpenCode can use `gh` to read issues, open
+     pull requests, fetch PR diffs, comment on PRs, check CI status, and
+     create repos, all without the student leaving their OpenCode session
+     or clicking around on github.com.
+
+     Install commands by platform:
+     - macOS: `brew install gh`
+     - Windows: `winget install --id GitHub.cli` (or use scoop/choco)
+     - Linux: follow https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+
+     Then authenticate with `gh auth login` (the web flow is fastest).
+     GitHub Desktop's authentication does not carry over to gh, so this
+     step is needed even if the student is already signed in to Desktop.
+     Verify with `gh auth status` and `gh --version`.
+
+  3. Suggest adding a gh rule to the student's global AGENTS.md at
+     `~/.config/opencode/AGENTS.md`. Show the student the proposed text
+     before writing anything, for example:
+
+         Use the gh CLI for any GitHub task: issues, pull requests,
+         repositories, releases, and checks. Prefer it over web
+         browsing or generic curl calls.
+
+     Ask the student if they want you to append this rule to their global
+     AGENTS.md. If they say yes, append it. If the file does not exist
+     yet, offer to create it. Do not write to AGENTS.md silently.
+
+  4. Explain what Git is: a version control system that records every
      change to every file. Emphasize that Git is useful even locally with
      no remote: every commit is a snapshot you can return to, so nothing
      is ever truly lost.
 
-  3. Explain what GitHub is: a cloud platform for hosting Git
+  5. Explain what GitHub is: a cloud platform for hosting Git
      repositories, backing up projects, collaborating, and sharing work.
 
-  4. Create or navigate to a project folder and initialize a Git
+  6. Create or navigate to a project folder and initialize a Git
      repository with `git init`. Explain what this does (creates a hidden
      .git directory that stores the project's history).
 
-  5. Have the student create or edit a file, then walk them through the
+  7. Have the student create or edit a file, then walk them through the
      staging and commit workflow: `git add <file>`,
      `git commit -m "message"`. Explain what staging is and why commits
      need messages.
 
-  6. Make another change and show the diff: `git diff` on the command
-     line, or use GitHub Desktop to visualize what changed. This is the
-     key insight: when OpenCode edits files, Git lets you see exactly what
-     was added, removed, or modified.
+  8. Make another change and review the diff. Use GitHub Desktop as the
+     primary way to visualize the change, since it shows additions and
+     removals side by side in a GUI. Mention `git diff` as the equivalent
+     CLI command. This is the key insight: when OpenCode edits files,
+     Git lets you see exactly what was added, removed, or modified.
 
-  7. Help them create a repository on GitHub (via GitHub Desktop or
-     `gh repo create`) and push their commits. Let them choose public or
-     private.
+  9. Help them create a repository on GitHub and push their commits.
+     GitHub Desktop's "Publish repository" button is the easiest path,
+     and `gh repo create` is the CLI equivalent. Let them choose public
+     or private.
 
-  8. Introduce branches: create a branch with
-     `git checkout -b experiment`, make a change, commit it, then switch
-     back to the main branch with `git checkout main` to show the change
-     disappears. Explain this as a way to try things without affecting
-     working code.
+  10. Introduce branches: create a branch with
+      `git checkout -b experiment`, make a change, commit it, then switch
+      back to the main branch with `git checkout main` to show the change
+      disappears. Explain this as a way to try things without affecting
+      working code.
 
   After the core steps, explain that the most valuable thing anyone can
   do as an open-source contributor is share ideas and report issues on
   GitHub. This does not require any of the Git setup you just walked
-  through — just a GitHub account. Point them at
+  through, just a GitHub account. Point them at
   {origin}/contributing for the full picture.
 
   Then offer two paths for completing this exercise:
@@ -79,9 +116,11 @@ agentInstructions: |
   4. Help them find a small, real improvement to make. Good options:
      - Fix a typo or unclear sentence in a lesson or page they've
        already read.
-     - Pick an open issue they'd like to take on. Browse
-       https://github.com/opencodeschool/opencode.school/issues and
-       search before choosing, so they don't duplicate existing work.
+     - Pick an open issue they'd like to take on. Use
+       `gh issue list --repo opencodeschool/opencode.school` to browse,
+       and `gh issue view <number> --repo opencodeschool/opencode.school`
+       to read details. Search before choosing so they don't duplicate
+       existing work.
      - Make a small clarification to the glossary, tips, or
        troubleshooting pages.
      Encourage them to pick something small for their first PR.
@@ -91,16 +130,17 @@ agentInstructions: |
   6. Push the branch to their fork.
 
   7. Open a pull request against `opencodeschool/opencode.school:main`
-     via `gh pr create --web` or GitHub Desktop's "Create Pull Request"
-     button. Help them write a concise title and body that explains what
-     changed and why.
+     using `gh pr create --web`. GitHub Desktop's "Create Pull Request"
+     button works too. Help them write a concise title and body that
+     explains what changed and why.
 
   8. Have the student share the PR URL with you. Confirm the URL exists
      and points at a PR in the opencodeschool/opencode.school repo.
 
   Mark the exercise complete if either path reaches its end state: Path A
   requires at least two commits pushed to a GitHub repo; Path B requires
-  an open PR against opencodeschool/opencode.school.
+  an open PR against opencodeschool/opencode.school. In both paths,
+  confirm `gh auth status` succeeds before marking complete.
 
   Whichever path they choose, close with a reminder: filing GitHub issues
   about anything confusing, broken, or missing is always welcome and
@@ -109,22 +149,51 @@ agentInstructions: |
 
 import AgentPrompt from '../../components/AgentPrompt.astro'
 
-When OpenCode edits files in your project, you want to know exactly what changed. [Git](https://git-scm.com) gives you that visibility. It's a version control system that tracks every change to every file in a project — what was added, what was removed, and when. It's the tool software developers use to manage source code, and it's the backbone of nearly every open-source project.
+When OpenCode edits files in your project, you want to know exactly what changed. [Git](https://git-scm.com) gives you that visibility. It's a version control system that tracks every change to every file in a project: what was added, what was removed, and when. It's the tool software developers use to manage source code, and it's the backbone of nearly every open-source project.
 
 But you don't need to be a developer or share your work with anyone to benefit from Git. Even if you only use it locally, Git gives you a complete history of your project. Every commit is a snapshot you can return to. If OpenCode makes a change you don't like, you can revert it. You never have to worry about accidentally losing or overwriting work.
 
 [GitHub](https://github.com) is a platform for hosting Git repositories in the cloud. It makes it easy to back up your projects, share them publicly, and collaborate with others. Together, Git and GitHub form the standard toolkit for managing code, and they work just as well for any project with files you want to track.
 
+This exercise sets you up with two ways to interact with GitHub: a GUI for inspecting changes (GitHub Desktop), and a CLI that OpenCode itself can drive on your behalf (the `gh` CLI).
+
 <AgentPrompt title="Use Git and GitHub" prompt='Let&#39;s work on the "Use Git and GitHub" exercise together!' />
 
 ## Get started with GitHub Desktop
 
-The easiest way to get Git running is to install [GitHub Desktop](https://desktop.github.com/). It handles three things at once: installing Git on your machine, creating a GitHub account if you don't have one, and authenticating the Git CLI so commands like `git push` work automatically.
+The recommended starting point is to install [GitHub Desktop](https://desktop.github.com/). It is the easiest way to get from zero to a working Git setup, because it does three things in one install:
 
-If you already use Git from the command line, you can skip GitHub Desktop entirely. The exercise works either way.
+1. Installs Git on your machine, so commands like `git --version` and `git push` work in your terminal.
+2. Lets you sign up for GitHub or sign in to an existing account directly from the app.
+3. Authenticates the Git CLI for you, so you can push to GitHub from the command line without setting up SSH keys or personal access tokens.
+
+Once you've cloned or created a repository in GitHub Desktop, it also gives you a GUI for browsing your project's history and visualizing exactly what changed in each commit. That visualization is the simplest way to review what OpenCode did to your files: every addition is highlighted in green, every removal in red.
+
+If you already have Git and a GitHub account, you can skip GitHub Desktop. The exercise still works.
+
+## Install the gh CLI
+
+The [`gh` CLI](https://cli.github.com/) is GitHub's official command-line tool. Installing it is required for this exercise. The reason is simple: with `gh` installed, OpenCode can read issues, open pull requests, fetch PR diffs, leave comments, check CI status, and create repositories on your behalf, all without you leaving your OpenCode session or clicking around on github.com.
+
+Install it for your platform:
+
+- macOS: `brew install gh`
+- Windows: `winget install --id GitHub.cli`
+- Linux: follow the [official Linux instructions](https://github.com/cli/cli/blob/trunk/docs/install_linux.md)
+
+Then authenticate:
+
+```
+gh auth login
+```
+
+The web flow is the fastest path. Note that signing in to GitHub Desktop does not authenticate `gh` for you, so you need this step even if Desktop is already set up. Verify with `gh auth status`.
+
+While you're at it, OpenCode will offer to add a rule to your global `~/.config/opencode/AGENTS.md` reminding it to prefer `gh` for any GitHub task. Say yes if you'd like every future session to default to using the CLI for issues, PRs, and repos.
 
 ## What you'll do
 
+- Install GitHub Desktop and the `gh` CLI, and add a `gh` rule to your global AGENTS.md
 - Initialize a repository in a project folder so Git starts tracking changes
 - Make commits: save snapshots of your work with a short description of what changed
 - Review diffs: use GitHub Desktop or `git diff` to see exactly what OpenCode changed in your files
@@ -137,6 +206,6 @@ Once the basics are working, you can go further: write a `.gitignore` to keep cl
 
 Once you're comfortable with commits, branches, and GitHub, you're ready to make your first real open-source contribution. This exercise includes an optional second path where OpenCode walks you through forking the [OpenCode School repository](https://github.com/opencodeschool/opencode.school), making a small improvement, and opening a pull request against it.
 
-You don't have to take this path to finish the exercise. If you'd rather stick with your own repo, that's fine. But if you've ever wanted to contribute to open source, this is a low-stakes way to do it. OpenCode will help you find a small change to make and walk you through every step.
+You don't have to take this path to finish the exercise. If you'd rather stick with your own repo, that's fine. But if you've ever wanted to contribute to open source, this is a low-stakes way to do it. OpenCode will help you find a small change to make and walk you through every step, using `gh` to browse open issues and open the PR for you.
 
 And remember: you don't need any of this to help improve OpenCode School. Filing a GitHub issue about something confusing, broken, or missing is always welcome and doesn't require Git at all. See [Contributing](/contributing) for more.

--- a/src/content/exercises/07-use-git-and-github.mdx
+++ b/src/content/exercises/07-use-git-and-github.mdx
@@ -10,7 +10,17 @@ agentInstructions: |
 
   Core steps (always do these):
 
-  1. Install GitHub Desktop as the primary on-ramp. Direct the student to
+  1. Explain what Git is, concisely: a version control system that records
+     every change to every file. Every commit is a snapshot you can return
+     to, so nothing is ever truly lost. Git is useful even locally with no
+     remote.
+
+  2. Explain what GitHub is, concisely: a cloud platform for hosting Git
+     repositories. It backs up projects, makes them shareable, and is
+     where open-source collaboration happens. Git is the tool; GitHub is
+     a place to host the repos that Git creates.
+
+  3. Install GitHub Desktop as the primary on-ramp. Direct the student to
      https://desktop.github.com/ and have them install it. Explain why
      this is the recommended starting point: GitHub Desktop bundles three
      things into one install. It installs Git on their machine, it lets
@@ -24,7 +34,7 @@ agentInstructions: |
      can still install GitHub Desktop for the diff GUI, or skip it. Verify
      Git is available with `git --version` either way.
 
-  2. Install the gh CLI. This is required for this exercise, not optional.
+  4. Install the gh CLI. This is required for this exercise, not optional.
      Explain why: agents like OpenCode can use `gh` to read issues, open
      pull requests, fetch PR diffs, comment on PRs, check CI status, and
      create repos, all without the student leaving their OpenCode session
@@ -40,7 +50,7 @@ agentInstructions: |
      step is needed even if the student is already signed in to Desktop.
      Verify with `gh auth status` and `gh --version`.
 
-  3. Suggest adding a gh rule to the student's global AGENTS.md at
+  5. Suggest adding a gh rule to the student's global AGENTS.md at
      `~/.config/opencode/AGENTS.md`. Show the student the proposed text
      before writing anything, for example:
 
@@ -51,14 +61,6 @@ agentInstructions: |
      Ask the student if they want you to append this rule to their global
      AGENTS.md. If they say yes, append it. If the file does not exist
      yet, offer to create it. Do not write to AGENTS.md silently.
-
-  4. Explain what Git is: a version control system that records every
-     change to every file. Emphasize that Git is useful even locally with
-     no remote: every commit is a snapshot you can return to, so nothing
-     is ever truly lost.
-
-  5. Explain what GitHub is: a cloud platform for hosting Git
-     repositories, backing up projects, collaborating, and sharing work.
 
   6. Create or navigate to a project folder and initialize a Git
      repository with `git init`. Explain what this does (creates a hidden
@@ -149,15 +151,21 @@ agentInstructions: |
 
 import AgentPrompt from '../../components/AgentPrompt.astro'
 
-When OpenCode edits files in your project, you want to know exactly what changed. [Git](https://git-scm.com) gives you that visibility. It's a version control system that tracks every change to every file in a project: what was added, what was removed, and when. It's the tool software developers use to manage source code, and it's the backbone of nearly every open-source project.
-
-But you don't need to be a developer or share your work with anyone to benefit from Git. Even if you only use it locally, Git gives you a complete history of your project. Every commit is a snapshot you can return to. If OpenCode makes a change you don't like, you can revert it. You never have to worry about accidentally losing or overwriting work.
-
-[GitHub](https://github.com) is a platform for hosting Git repositories in the cloud. It makes it easy to back up your projects, share them publicly, and collaborate with others. Together, Git and GitHub form the standard toolkit for managing code, and they work just as well for any project with files you want to track.
-
-This exercise sets you up with two ways to interact with GitHub: a GUI for inspecting changes (GitHub Desktop), and a CLI that OpenCode itself can drive on your behalf (the `gh` CLI).
+Git gives you a way to see every change as it happens, so you're not flying blind while OpenCode works on your project. GitHub gives you a place to safely store your work and collaborate with others. Learning these tools will give you more confidence on your own projects, and set you up to become an open-source contributor.
 
 <AgentPrompt title="Use Git and GitHub" prompt='Let&#39;s work on the "Use Git and GitHub" exercise together!' />
+
+## What is Git?
+
+[Git](https://git-scm.com) is a version control system that records every change to every file in a project. Each commit is a snapshot you can return to, so nothing is ever truly lost: if OpenCode makes a change you don't like, you can revert it.
+
+Git works entirely on your own machine. You don't need an account, a server, or an internet connection to benefit from it. Even with no remote, Git gives you a complete history of your project.
+
+## What is GitHub?
+
+[GitHub](https://github.com) is a cloud platform for hosting Git repositories. It's where you back up your work, share projects publicly or privately, and collaborate with other people. It's also where most of the open-source world lives.
+
+The two are easy to mix up: Git is the tool that tracks changes on your machine, and GitHub is one popular place to host the repositories that Git creates.
 
 ## Get started with GitHub Desktop
 

--- a/src/content/exercises/07-use-git-and-github.mdx
+++ b/src/content/exercises/07-use-git-and-github.mdx
@@ -169,7 +169,7 @@ The two are easy to mix up: Git is the tool that tracks changes on your machine,
 
 ## Get started with GitHub Desktop
 
-The recommended starting point is to install [GitHub Desktop](https://desktop.github.com/). It is the easiest way to get from zero to a working Git setup, because it does three things in one install:
+[GitHub Desktop](https://desktop.github.com/) is a great GitHub interface for humans. It is also the easiest way to get from zero to a working Git setup, because it does three things in one install:
 
 1. Installs Git on your machine.
 2. Lets you sign up for GitHub or sign in to an existing account directly from the app.
@@ -181,7 +181,7 @@ If you already have Git and a GitHub account, you can skip GitHub Desktop. The e
 
 ## Install the gh CLI
 
-The [`gh` CLI](https://cli.github.com/) is GitHub's official command-line tool. With `gh` installed, OpenCode can read issues, open pull requests, fetch PR diffs, leave comments, check CI status, and create repositories on your behalf, all without you leaving your session.
+If GitHub Desktop is GitHub's interface for humans, the [`gh` CLI](https://cli.github.com/) is GitHub's interface for agents. With `gh` installed, OpenCode can read issues, open pull requests, fetch PR diffs, leave comments, check CI status, and create repositories on your behalf, all without you leaving your session.
 
 You'll install it as part of this exercise and start using it from OpenCode right away.
 


### PR DESCRIPTION
This PR reworks the Git/GitHub exercise to lead with GitHub Desktop as the primary on-ramp and to make installing the `gh` CLI a required step.

GitHub Desktop is now framed up front as a single install that gives the student Git, a GitHub account flow, an authenticated Git CLI, and a GUI for visualizing what OpenCode changed in their files.

The `gh` CLI is now required because it lets OpenCode read issues, open and review PRs, fetch diffs, and create repos directly from a session, instead of asking the student to click around on github.com. The exercise also walks the student through adding a global AGENTS.md rule that tells OpenCode to prefer `gh` for any GitHub task, with the agent showing the proposed text and asking before writing.

Path B (the contribution path) now uses `gh issue list` and `gh issue view` for browsing open issues, and continues to use `gh pr create --web` for opening the PR.

Closes #182.