### PR TITLE
docs: clarify YouTube Filters button location in edit-videos exercise

### DIFF
--- a/src/content/exercises/03-edit-videos.mdx
+++ b/src/content/exercises/03-edit-videos.mdx
@@ -73,7 +73,7 @@ On Linux, use your system package manager or Homebrew. On Windows, download FFMP
 
 You'll start by finding a [Creative Commons](https://creativecommons.org)-licensed video on YouTube — these are videos the creator has explicitly marked as free to reuse.
 
-To find one: search YouTube for a topic that interests you, click **Filters**, then under **Features** select **Creative Commons**. Pick something short (under 5 minutes) with visuals you find interesting — nature footage, city timelapses, and music videos tend to work well.
+To find one: search YouTube for a topic that interests you. On the search results page, look for the **Filters** button just below the search bar — it may be hidden until you run a search. Click it, then under **Features** select **Creative Commons**. If you can't find the Filters button, try adding "creative commons" to your search term instead (e.g. "nature timelapse creative commons"). Pick something short (under 5 minutes) with visuals you find interesting — nature footage, city timelapses, and music videos tend to work well.
 
 ## What you'll do
 


### PR DESCRIPTION
## What changed

The 'Find a video' section in the Edit Videos exercise now includes clearer guidance on where to find the YouTube Filters button, and a fallback tip for when it's not visible.

## Why

During the exercise, the Filters button was hard to find because it only appears on the search results page (not the homepage), and its location wasn't described. A student also had to ask for help mid-exercise because of this.

## Changes

- Clarified that Filters appears on the search results page, just below the search bar
- Added a fallback: adding 'creative commons' to the search term as an alternative if the button can't be found