### PR TITLE
fix: tolerate blocked enrollment storage

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -321,26 +321,53 @@ const currentPath = Astro.url.pathname;
     </script>
     <script is:inline>
       // Progress tracking API — defined in <head> so page-level scripts can use it
+      const schoolMemoryStorage = {};
+
+      function readSchoolStorage(key) {
+        try {
+          const value = localStorage.getItem(key);
+          return value === null ? schoolMemoryStorage[key] || null : value;
+        } catch {
+          return schoolMemoryStorage[key] || null;
+        }
+      }
+
+      function writeSchoolStorage(key, value) {
+        schoolMemoryStorage[key] = value;
+        try {
+          localStorage.setItem(key, value);
+        } catch {
+          // Some browsers/extensions block localStorage. Keep the current page working.
+        }
+      }
+
+      function createDeviceId() {
+        if (window.crypto && typeof window.crypto.randomUUID === "function") {
+          return window.crypto.randomUUID();
+        }
+        return `device-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      }
+
       window.school = {
         getStudentId() {
-          return localStorage.getItem("studentId");
+          return readSchoolStorage("studentId");
         },
 
         setStudentId(id) {
-          localStorage.setItem("studentId", id);
+          writeSchoolStorage("studentId", id);
         },
 
         getDeviceId() {
-          let deviceId = localStorage.getItem("deviceId");
+          let deviceId = readSchoolStorage("deviceId");
           if (!deviceId) {
-            deviceId = crypto.randomUUID();
-            localStorage.setItem("deviceId", deviceId);
+            deviceId = createDeviceId();
+            writeSchoolStorage("deviceId", deviceId);
           }
           return deviceId;
         },
 
         getThemeColor() {
-          return localStorage.getItem("themeColor") || "blue";
+          return readSchoolStorage("themeColor") || "blue";
         },
 
         getThemePalettes() {
@@ -350,14 +377,14 @@ const currentPath = Astro.url.pathname;
         setThemeColor(themeName) {
           const palettes = this.getThemePalettes();
           const nextTheme = palettes[themeName] ? themeName : "blue";
-          localStorage.setItem("themeColor", nextTheme);
+          writeSchoolStorage("themeColor", nextTheme);
           window.__applySchoolTheme(nextTheme);
           return nextTheme;
         },
 
         getCachedProgress() {
           try {
-            const p = JSON.parse(localStorage.getItem("progress") || "null");
+            const p = JSON.parse(readSchoolStorage("progress") || "null");
             this._progressCache = p;
             return p;
           } catch { return null; }
@@ -365,7 +392,7 @@ const currentPath = Astro.url.pathname;
 
         setCachedProgress(progress) {
           this._progressCache = progress;
-          localStorage.setItem("progress", JSON.stringify(progress));
+          writeSchoolStorage("progress", JSON.stringify(progress));
         },
 
         _progressCache: null,
@@ -396,7 +423,7 @@ const currentPath = Astro.url.pathname;
 
         getVisitedLessons() {
           try {
-            return JSON.parse(localStorage.getItem("visitedLessons") || "[]");
+            return JSON.parse(readSchoolStorage("visitedLessons") || "[]");
           } catch { return []; }
         },
 
@@ -408,7 +435,7 @@ const currentPath = Astro.url.pathname;
           const visited = this.getVisitedLessons();
           if (!visited.includes(slug)) {
             visited.push(slug);
-            localStorage.setItem("visitedLessons", JSON.stringify(visited));
+            writeSchoolStorage("visitedLessons", JSON.stringify(visited));
           }
         },
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -165,7 +165,7 @@ const exercises = (await getCollection("exercises")).sort((a, b) => a.data.order
         <button type="button" class="enrollment-color-option h-12 w-full rounded-xl border-2 border-transparent shadow-sm" data-theme-color="rose"    aria-label="Rose"    title="Rose"    style="background:#e11d48;--i:16"></button>
         <button type="button" class="enrollment-color-option h-12 w-full rounded-xl border-2 border-transparent shadow-sm" data-theme-color="slate"   aria-label="Slate"   title="Slate"   style="background:#475569;--i:17"></button>
       </div>
-      <p id="enroll-error" class="mt-2 text-red-500 text-sm hidden">Something went wrong. Please try again.</p>
+      <p id="enroll-error" class="mt-2 text-red-500 text-sm hidden">Something went wrong. Please try again. If it keeps happening, clear site data or disable browser extensions for this site.</p>
     </div>
   </div>
 
@@ -438,6 +438,7 @@ const exercises = (await getCollection("exercises")).sort((a, b) => a.data.order
             var data = await window.school.enroll();
             showEnrolled(data.studentId, true, false);
           } catch (e) {
+            console.error("Enrollment failed", e);
             enrollError.classList.remove("hidden");
             setPickerState("Choose a color for your student ID card and site theme.", false);
             isSubmitting = false;


### PR DESCRIPTION
This PR makes enrollment tolerate blocked or broken browser storage. It wraps the shared school storage reads and writes with an in-memory fallback, avoids failing when device ID creation cannot persist to localStorage, and adds a clearer enrollment error message with console logging for diagnosis.

Fixes https://github.com/opencodeschool/opencode.school/issues/192