### PR TITLE
fix(exercises): remove duplicate Fayaz Ahmed link in mac apps exercise

### DIFF
--- a/src/content/exercises/10-build-native-mac-apps.mdx
+++ b/src/content/exercises/10-build-native-mac-apps.mdx
@@ -91,7 +91,7 @@ import AgentPrompt from '../../components/AgentPrompt.astro'
 
 So far you've used OpenCode to build and deploy web apps, edit files and videos, run AI models, and automate your browser. You can also use OpenCode to build native macOS apps with Swift and Xcode. You'll start with an existing open-source app created by open-source developer [Fayaz Ahmed](https://github.com/fayazara), building it from source, running it, and making a change, to get a sense of how the app development process works. Once you've been through the flow, you can optionally start a new app of your own from scratch. A skill teaches OpenCode the native patterns it needs along the way.
 
-The app is [OpenCode Stats](https://github.com/fayazara/opencode-stats) by [Fayaz Ahmed](https://github.com/fayazara), a native macOS menu bar app that shows your own OpenCode usage stats: cost, sessions, tokens, tools, and per-project breakdowns, all read from the local OpenCode database. It's fitting: you'll use OpenCode to build an app about OpenCode.
+The app is [OpenCode Stats](https://github.com/fayazara/opencode-stats) by Fayaz Ahmed, a native macOS menu bar app that shows your own OpenCode usage stats: cost, sessions, tokens, tools, and per-project breakdowns, all read from the local OpenCode database. It's fitting: you'll use OpenCode to build an app about OpenCode.
 
 <figure class="text-center my-8">
   <img src="/images/opencode-stats-screenshot.jpg" alt="The OpenCode Stats app showing usage statistics including cost, sessions, token breakdown, and per-project costs" class="rounded-lg mx-auto" />


### PR DESCRIPTION
This PR removes a redundant link in the "Build native Mac apps" exercise. The prose linked "Fayaz Ahmed" to https://github.com/fayazara in two consecutive paragraphs. The first mention keeps the link; the second is now plain text.