### PR TITLE
Add tip for interrupting a stuck model

### DIFF
--- a/src/pages/tips.astro
+++ b/src/pages/tips.astro
@@ -63,6 +63,13 @@ import Base from "../layouts/Base.astro";
       instructions.
     </p>
 
+    <h2>Interrupt a stuck model</h2>
+    <p>
+      If OpenCode seems stuck and nothing has happened for a while, press
+      <kbd>Escape</kbd> twice. That interrupts the current turn so you can send a
+      follow-up message like, "I think you got stuck; please keep going."
+    </p>
+
     <h2>Open a higher-level directory for broader access</h2>
     <p>
       OpenCode is scoped to the directory where you start it. If you have been


### PR DESCRIPTION
## Summary
- Add a Tips and Tricks entry explaining that pressing Escape twice can interrupt a stuck model turn.

Closes #160