### PR TITLE
Fix broken links and correct FFMPEG to FFmpeg

### DIFF
--- a/src/content/exercises/03-edit-videos.mdx
+++ b/src/content/exercises/03-edit-videos.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Edit videos"
 slug: edit-videos
-description: "Edit videos from the command line using FFMPEG and yt-dlp."
+description: "Edit videos from the command line using FFmpeg and yt-dlp."
 order: 3
 agentInstructions: |
-  Guide the student through video editing with FFMPEG and yt-dlp. Adapt
+  Guide the student through video editing with FFmpeg and yt-dlp. Adapt
   depth to their profile.
 
   Steps:
 
-  1. Install FFMPEG and yt-dlp. On macOS use Homebrew:
+  1. Install FFmpeg and yt-dlp. On macOS use Homebrew:
      `brew install ffmpeg yt-dlp`. On Linux: use the system package
      manager (apt, dnf, etc.) or Homebrew. On Windows: guide them to
      download from ffmpeg.org and github.com/yt-dlp/yt-dlp. Verify both
@@ -53,9 +53,9 @@ agentInstructions: |
 
 import AgentPrompt from '../../components/AgentPrompt.astro'
 
-FFMPEG is one of the most powerful and widely-used tools in the world for working with audio and video. It powers the encoding behind YouTube, Netflix, Spotify, and countless other services. It can convert between formats, extract audio, chop clips, generate thumbnails, create GIFs, add watermarks, and much more — all from the command line.
+FFmpeg is one of the most powerful and widely-used tools in the world for working with audio and video. It powers the encoding behind YouTube, Netflix, Spotify, and countless other services. It can convert between formats, extract audio, chop clips, generate thumbnails, create GIFs, add watermarks, and much more — all from the command line.
 
-In this exercise, you'll pair FFMPEG with [yt-dlp](https://github.com/yt-dlp/yt-dlp), a tool for downloading video from YouTube and other sites. Together they're a toolkit for downloading, inspecting, and manipulating video — and OpenCode makes the whole process conversational.
+In this exercise, you'll pair FFmpeg with [yt-dlp](https://github.com/yt-dlp/yt-dlp), a tool for downloading video from YouTube and other sites. Together they're a toolkit for downloading, inspecting, and manipulating video — and OpenCode makes the whole process conversational.
 
 <AgentPrompt title="Edit videos" prompt='Let&#39;s work on the "Edit videos" exercise together!' />
 
@@ -67,7 +67,7 @@ Both tools are available through [Homebrew](https://brew.sh) on macOS:
 brew install ffmpeg yt-dlp
 ```
 
-On Linux, use your system package manager or Homebrew. On Windows, download FFMPEG from [ffmpeg.org](https://ffmpeg.org/download.html) and yt-dlp from [GitHub](https://github.com/yt-dlp/yt-dlp/releases).
+On Linux, use your system package manager or Homebrew. On Windows, download FFmpeg from [ffmpeg.org](https://ffmpeg.org/download.html) and yt-dlp from [GitHub](https://github.com/yt-dlp/yt-dlp/releases).
 
 ## Find a video
 
@@ -77,7 +77,7 @@ To find one: search YouTube for a topic that interests you. On the search result
 
 ## What you'll do
 
-Once you have a video, you'll use FFMPEG to take it apart and put it back together:
+Once you have a video, you'll use FFmpeg to take it apart and put it back together:
 
 - **Download** the video from YouTube using yt-dlp
 - **Inspect** the video's metadata — resolution, duration, codecs, frame rate

--- a/src/content/exercises/04-transcribe-speech.mdx
+++ b/src/content/exercises/04-transcribe-speech.mdx
@@ -69,7 +69,7 @@ You'll need two tools:
 brew install whisper-cpp ffmpeg
 ```
 
-[whisper-cpp](https://github.com/ggerganov/whisper.cpp) runs the transcription model. [FFMPEG](https://ffmpeg.org) converts audio files to the 16kHz WAV format that Whisper requires. If you did the [Edit Videos](/exercises/edit-videos) exercise, you already have FFMPEG installed.
+[whisper-cpp](https://github.com/ggerganov/whisper.cpp) runs the transcription model. [FFmpeg](https://ffmpeg.org) converts audio files to the 16kHz WAV format that Whisper requires. If you did the [Edit Videos](/exercises/edit-videos) exercise, you already have FFmpeg installed.
 
 On Linux, build whisper-cpp from source or use your system package manager. See the [whisper.cpp repo](https://github.com/ggerganov/whisper.cpp) for instructions.
 

--- a/src/content/lessons/03-configuration.mdx
+++ b/src/content/lessons/03-configuration.mdx
@@ -157,7 +157,7 @@ Here's what your config file will look like:
 
 We'll substitute your actual student ID when we create the file. A few things to note:
 
-- `"default_agent": "plan"` means every new session starts in [Plan mode](/glossary#agent) — a read-only agent that can read your files and discuss your project but won't make any changes. When you're ready to act, you switch to Build. We'll cover this in detail in the [Agents](/agents) lesson.
+- `"default_agent": "plan"` means every new session starts in [Plan mode](/glossary#agent) — a read-only agent that can read your files and discuss your project but won't make any changes. When you're ready to act, you switch to Build. We'll cover this in detail in the [Agents](/lessons/agents) lesson.
 - `"edit": "allow"` and `"webfetch": "allow"` are set explicitly because some providers push a remote config (via `.well-known/opencode`) that sets these tools to `"ask"`. Explicit per-tool rules override the `"*"` wildcard during config merging, so without these you may still get prompted for every file edit and web fetch even though you set `"*": "allow"`.
 - `"external_directory": "ask"` means OpenCode will pause and ask before reading or editing files outside the current project directory. This is the default behavior, but setting it explicitly makes the config self-documenting.
 - The `"bash"` block inside `"permission"` adds safety guardrails for shell commands. Most commands run automatically, but `rm` (delete files) and `rmdir` (remove directories) will pause and ask for your approval first. We'll add more permission rules in the next lesson.

--- a/src/content/lessons/11-agents.mdx
+++ b/src/content/lessons/11-agents.mdx
@@ -45,7 +45,7 @@ OpenCode ships with two built-in agents: **Plan** and **Build**.
 
 Plan is a read-only conversational agent. It can read your files and discuss your project, but it won't make any changes. No files written, no commands run, nothing modified.
 
-You already set `"default_agent": "plan"` in your global config back in the [Configuration](/configuration) lesson, so every new session starts here. That's intentional — you think first, then act.
+You already set `"default_agent": "plan"` in your global config back in the [Configuration](/lessons/configuration) lesson, so every new session starts here. That's intentional — you think first, then act.
 
 That said, Plan mode is an instruction to the model, not a hard sandbox. Occasionally the agent may still make API calls or run commands that have side effects, so it's not a guaranteed protection against unintended changes.
 


### PR DESCRIPTION
Fixes two broken internal links in lesson content (/configuration → /lessons/configuration, /agents → /lessons/agents) that were returning 404s. Also corrects FFMPEG to FFmpeg (official project name) across the edit-videos and transcribe-speech exercises.