### PR TITLE
Add tip about pressing Escape twice to interrupt a stuck agent

### DIFF
--- a/src/pages/tips.astro
+++ b/src/pages/tips.astro
@@ -52,6 +52,14 @@ import Base from "../layouts/Base.astro";
       tools or steps you expect.
     </p>
 
+    <h2>Press Escape twice to interrupt a stuck agent</h2>
+    <p>
+      Sometimes the agent goes silent — thinking for a long time with no progress.
+      Pressing <kbd>Escape</kbd> twice will interrupt the agent and return control
+      to you. Then you can send a message like "You seem stuck, keep going" or
+      redirect the agent entirely.
+    </p>
+
     <h2>Know when to give up and start over</h2>
     <p>
       Sometimes you end up in a rabbit hole: the agent makes a mistake, you try


### PR DESCRIPTION
Implements the suggestion from issue #160.

Adds a new tip to the tips page explaining that pressing Escape twice will interrupt a stuck agent and return control to the user, giving them a chance to redirect or re-prompt the agent.

Closes #160