### PR TITLE
Add "Learn anything" exercise

### DIFF
--- a/src/content/exercises/11-learn-anything.mdx
+++ b/src/content/exercises/11-learn-anything.mdx
@@ -1,0 +1,103 @@
+---
+title: "Learn anything"
+slug: learn-anything
+description: "Install Matt Pocock's /teach skill and use OpenCode to build a bespoke curriculum for anything you want to learn."
+order: 11
+agentInstructions: |
+  Guide the student through installing and using the /teach skill
+  (https://github.com/mattpocock/skills/tree/main/skills/productivity/teach),
+  a user-invoked skill that turns OpenCode into a personal tutor for any
+  topic, not just software or AI. Adapt depth and pace to the student's
+  profile.
+
+  Steps:
+
+  1. Install the teach skill globally and non-interactively with
+     `npx skills add mattpocock/skills --skill teach --agent opencode -g -y`.
+     This installs just the `teach` skill from Matt Pocock's larger skills
+     repo, scoped to OpenCode, for all projects. Tell the student to quit
+     and reopen OpenCode Desktop so the skill loads.
+
+  2. Help the student pick a topic to learn, if they haven't already.
+     Offer three example ideas spanning distinct, non-technical domains:
+     solving a Rubik's Cube, home sourdough baking, or building a personal
+     investment portfolio, to make clear this works for anything, not
+     just coding or AI. Let them choose their own topic instead if
+     they'd rather.
+
+  3. Explain that /teach treats the current directory as a stateful
+     teaching workspace, so help the student create and switch into a new,
+     dedicated folder for this topic (e.g. `mkdir learn-rubiks-cube && cd
+     learn-rubiks-cube`) before running the skill. Do not run it inside
+     the OpenCode School project or another unrelated project.
+
+  4. Run `/teach` in OpenCode from that folder. The skill will interview
+     the student about why they want to learn the topic and what they
+     already know. Encourage the student to answer honestly and in their
+     own words so the resulting curriculum fits them, not a generic
+     student. This grounds the workspace's MISSION.md.
+
+  5. Let the skill generate the student's first lesson. It should produce
+     a self-contained HTML file under ./lessons/ in the workspace,
+     tailored to what the student just described. Open the lesson file
+     for the student (e.g. `open lessons/0001-*.html` on macOS, or the
+     equivalent for their platform) and have them read through it.
+
+  6. Encourage the student to notice the format: lessons are short,
+     visual, and tied to a single tangible win, not a wall of text. If the
+     lesson includes a quiz or interactive element, have the student try
+     it. Point out that they can keep running /teach in this same folder
+     later to get the next lesson, adapted to what they've learned so
+     far.
+
+  Verify completion by checking that the workspace directory contains a
+  populated MISSION.md and at least one lesson file under ./lessons/. If
+  you cannot inspect the filesystem directly, ask the student to confirm
+  both exist and briefly describe what their first lesson covered.
+---
+
+import AgentPrompt from '../../components/AgentPrompt.astro'
+
+You've used OpenCode to build things: websites, apps, videos, social posts. This exercise flips that around. Instead of building software, you'll use OpenCode to build yourself a personal curriculum, on absolutely anything, using [Matt Pocock](https://github.com/mattpocock)'s `/teach` skill.
+
+The skill interviews you first, just like OpenCode School does, to understand what you already know and why you want to learn it. Then it generates lessons just for you: short, visual, single-file pages with graphics, interactive elements, and quizzes, saved to a folder on your own machine. You can keep coming back to the same folder to get more lessons, each one picking up where the last left off.
+
+<AgentPrompt title="Learn anything" prompt='Let&#39;s work on the "Learn anything" exercise together!' />
+
+## Prerequisites
+
+You'll need [Node.js](https://nodejs.org) installed, since the skill installer runs via `npx`. Check with `node --version`.
+
+## The skill
+
+[`/teach`](https://github.com/mattpocock/skills/tree/main/skills/productivity/teach) is one skill from Matt Pocock's larger [`skills`](https://github.com/mattpocock/skills) repository, a collection of agent skills for engineering and productivity. Install just the `teach` skill, scoped to OpenCode, globally:
+
+```
+npx skills add mattpocock/skills --skill teach --agent opencode -g -y
+```
+
+Skills load at startup, so **quit and reopen OpenCode Desktop** after installing.
+
+Unlike some skills that OpenCode reaches for automatically, `/teach` is invoked directly by you, by typing `/teach`. It treats whatever folder you run it from as a persistent teaching workspace, so start by creating a new, dedicated folder for the topic you want to learn, separate from any other project.
+
+## Pick something to learn
+
+The whole point of this exercise is that it isn't limited to code or AI. Matt has used it to learn how to solve a Rubik's Cube. Here are three ideas to get you thinking, each from a completely different world:
+
+- **Solving a Rubik's Cube**: the example from Matt's own post. Learn the notation, the first layer, and your first full solve.
+- **Home sourdough baking**: build and maintain a starter, learn hydration ratios, and bake your first loaf.
+- **Building a personal investment portfolio**: learn to read a company's financial statements, understand asset allocation and diversification, and reason about risk well enough to build a portfolio suited to your own goals.
+
+Or ignore all three and pick your own topic entirely. Anything you're curious about is fair game.
+
+## What you'll do
+
+- Install the `/teach` skill globally, scoped to OpenCode, and restart OpenCode Desktop.
+- Create a new folder to act as your teaching workspace for this topic.
+- Run `/teach` and answer its interview about your goals and existing knowledge.
+- Review the first bespoke lesson it generates, saved as an HTML file you can open and revisit.
+- Try any quiz or interactive element the lesson includes.
+
+## Keep going
+
+A single lesson is just the start. Run `/teach` again in the same folder whenever you want the next one, and the skill adapts to what you've already learned, building a whole personalized course over time, one lesson at a time.


### PR DESCRIPTION
## Summary

Adds a new exercise, "Learn anything", that has students install Matt Pocock's `/teach` skill and use it to build a bespoke, multi-session curriculum on any topic they choose, not just coding or AI.

- Installs just the `teach` skill from `mattpocock/skills`, globally and non-interactively, scoped to OpenCode: `npx skills add mattpocock/skills --skill teach --agent opencode -g -y`
- Walks through creating a dedicated teaching workspace folder, running `/teach`, answering its interview, and reviewing the first generated lesson
- Offers three example topics from distinct domains to make clear the skill isn't code/AI-specific: solving a Rubik's Cube, home sourdough baking, and building a personal investment portfolio, while leaving the topic fully open
- Verification checks for a populated `MISSION.md` and at least one lesson file under `./lessons/` in the workspace, falling back to asking the student if the filesystem can't be inspected

Appended as exercise #11 (order-based, no other files needed changes since the index/API/OpenAPI spec are all driven generically off the content collection).

## Testing

- `script/lint` passes
- `astro build` succeeds and renders `/exercises/learn-anything` correctly alongside the existing exercises

🤖 Generated with [OpenCode](https://opencode.ai)