### PR TITLE
docs: add tip about pressing Escape twice to unstick a stuck model

### DIFF
--- a/src/pages/tips.astro
+++ b/src/pages/tips.astro
@@ -63,6 +63,14 @@ import Base from "../layouts/Base.astro";
       instructions.
     </p>
 
+    <h2>Press Escape twice to unstick a stuck model</h2>
+    <p>
+      Sometimes the model will get stuck and you'll see nothing happening for a
+      long period of time. When that happens, press the Escape key twice, then
+      send a message like "Hey, are you awake?" or "I think you got stuck—keep
+      going."
+    </p>
+
     <h2>Open a higher-level directory for broader access</h2>
     <p>
       OpenCode is scoped to the directory where you start it. If you have been


### PR DESCRIPTION
Closes #160\n\nAdds a tip to the Tips and Tricks page explaining that pressing Escape twice can help unstick a model that appears to be stuck, then sending a short prompt like "Hey, are you awake?" to get it going again.