### PR TITLE
Add tip about nudging the agent when it goes quiet

### DIFF
--- a/src/pages/tips.astro
+++ b/src/pages/tips.astro
@@ -63,6 +63,19 @@ import Base from "../layouts/Base.astro";
       instructions.
     </p>
 
+    <h2>Nudge the agent when it goes quiet</h2>
+    <p>
+      Sometimes the model gets stuck and you will see nothing happening for a
+      long period of time. The agent is still running, but it is no longer
+      making useful progress.
+    </p>
+    <p>
+      When this happens, hit <kbd>Esc</kbd> twice to interrupt the current
+      turn, then send a message like "Hey, are you awake?" or "I think you
+      got stuck — keep going." This gives the agent a chance to recover,
+      summarize what it has done so far, and resume from a clean state.
+    </p>
+
     <h2>Open a higher-level directory for broader access</h2>
     <p>
       OpenCode is scoped to the directory where you start it. If you have been


### PR DESCRIPTION
Closes #160

Adds a new section to /tips describing what to do when the agent stops making useful progress: hit Esc twice to interrupt the current turn, then send a short message like "Hey, are you awake?" to give the agent a chance to recover and resume from a clean state.

Style matches the surrounding tip sections (single h2 + 2 short paragraphs).