### PR TITLE
Clarify gh CLI Linux install in git exercise

### DIFF
--- a/src/content/exercises/07-use-git-and-github.mdx
+++ b/src/content/exercises/07-use-git-and-github.mdx
@@ -43,7 +43,10 @@ agentInstructions: |
      Install commands by platform:
      - macOS: `brew install gh`
      - Windows: `winget install --id GitHub.cli` (or use scoop/choco)
-     - Linux: follow https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+      - Linux: download the `.deb` from https://cli.github.com/ and install it with
+        `sudo dpkg -i gh_*.deb`, or follow
+        https://github.com/cli/cli/blob/trunk/docs/install_linux.md for apt and
+        other package managers.
 
      Then authenticate with `gh auth login` (the web flow is fastest).
      GitHub Desktop's authentication does not carry over to gh, so this


### PR DESCRIPTION
The git exercise's Linux install step was just a bare link. This adds a concrete `.deb` install command (and points to the apt docs) so Linux readers can install `gh` without hunting.

Tested the `.deb` path on Ubuntu 24.04 and it installs `gh` cleanly.